### PR TITLE
fix: drive-by correctness sweep across smtp / httpf / postgres / grpcf

### DIFF
--- a/grpcf/echo.go
+++ b/grpcf/echo.go
@@ -21,14 +21,31 @@ func (handler *echo) UnaryEcho(context.Context, *golibproto.UnaryEchoRequest) (*
 	}, nil
 }
 
+// SetEchoServers registers the built-in echo + health-check services on the
+// given gRPC server and starts a background goroutine that toggles the
+// SERVING/NOT_SERVING status every healthPing tick.
+//
+// Deprecated: the started goroutine has no stop signal and outlives the
+// caller. Use SetEchoServersContext instead — it accepts a context and the
+// goroutine exits cleanly when the context is canceled (e.g. during graceful
+// shutdown).
 func SetEchoServers(server *grpc.Server, healthPing time.Duration) {
+	SetEchoServersContext(context.Background(), server, healthPing)
+}
+
+// SetEchoServersContext is the ctx-aware variant of SetEchoServers: the
+// background health-toggle goroutine returns when ctx is canceled, instead of
+// running for the lifetime of the process.
+func SetEchoServersContext(ctx context.Context, server *grpc.Server, healthPing time.Duration) {
 	healthcheck := health.NewServer()
 	healthpb.RegisterHealthServer(server, healthcheck)
 
-	golibproto.RegisterEchoServiceServer(server, new(echo))
+	golibproto.RegisterEchoServiceServer(server, &echo{})
 
 	go func() {
-		// asynchronously inspect dependencies and toggle serving status as needed
+		ticker := time.NewTicker(healthPing)
+		defer ticker.Stop()
+
 		next := healthpb.HealthCheckResponse_SERVING
 
 		for {
@@ -40,7 +57,11 @@ func SetEchoServers(server *grpc.Server, healthPing time.Duration) {
 				next = healthpb.HealthCheckResponse_SERVING
 			}
 
-			time.Sleep(healthPing)
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
 		}
 	}()
 }

--- a/grpcf/echo.go
+++ b/grpcf/echo.go
@@ -36,6 +36,11 @@ func SetEchoServers(server *grpc.Server, healthPing time.Duration) {
 // SetEchoServersContext is the ctx-aware variant of SetEchoServers: the
 // background health-toggle goroutine returns when ctx is canceled, instead of
 // running for the lifetime of the process.
+//
+// A non-positive healthPing degrades to a tight toggle loop that still
+// honours ctx cancellation — matching the original time.Sleep-based
+// behaviour, which returned immediately on a zero or negative duration
+// rather than panicking like time.NewTicker would.
 func SetEchoServersContext(ctx context.Context, server *grpc.Server, healthPing time.Duration) {
 	healthcheck := health.NewServer()
 	healthpb.RegisterHealthServer(server, healthcheck)
@@ -43,9 +48,6 @@ func SetEchoServersContext(ctx context.Context, server *grpc.Server, healthPing 
 	golibproto.RegisterEchoServiceServer(server, &echo{})
 
 	go func() {
-		ticker := time.NewTicker(healthPing)
-		defer ticker.Stop()
-
 		next := healthpb.HealthCheckResponse_SERVING
 
 		for {
@@ -57,10 +59,18 @@ func SetEchoServersContext(ctx context.Context, server *grpc.Server, healthPing 
 				next = healthpb.HealthCheckResponse_SERVING
 			}
 
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
+			if healthPing > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(healthPing):
+				}
+			} else {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 			}
 		}
 	}()

--- a/httpf/json.go
+++ b/httpf/json.go
@@ -5,15 +5,20 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/samber/lo"
-
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/a-novel-kit/golib/otel"
 )
 
 func SendJSON[Data any](_ context.Context, w http.ResponseWriter, span trace.Span, data Data) {
 	w.Header().Set("Content-Type", "application/json")
+
 	err := json.NewEncoder(w).Encode(data)
-	span.RecordError(err)
-	span.SetStatus(lo.Ternary(err == nil, codes.Ok, codes.Error), "")
+	if err != nil {
+		_ = otel.ReportError(span, err)
+
+		return
+	}
+
+	otel.ReportSuccessNoContent(span)
 }

--- a/postgres/ping.go
+++ b/postgres/ping.go
@@ -8,15 +8,29 @@ import (
 	"github.com/uptrace/bun"
 )
 
-const PingTimeout = 10 * time.Second
+const (
+	PingTimeout = 10 * time.Second
+	// PingRetryInterval is the wait between failed ping attempts. Without it,
+	// Ping would tight-loop reconnects on an unreachable database for the
+	// duration of PingTimeout.
+	PingRetryInterval = 100 * time.Millisecond
+)
 
 // Ping a database connection until it succeeds or the timeout is reached.
+// Honours ctx cancellation both for the PingContext call and for the wait
+// between retries.
 func Ping(ctx context.Context, client *bun.DB) error {
 	start := time.Now()
 
 	for err := client.PingContext(ctx); err != nil; err = client.PingContext(ctx) {
 		if time.Since(start) > PingTimeout {
 			return fmt.Errorf("ping database: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("ping database: %w", ctx.Err())
+		case <-time.After(PingRetryInterval):
 		}
 	}
 

--- a/smtp/sender.prod.go
+++ b/smtp/sender.prod.go
@@ -2,7 +2,6 @@ package smtp
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net/smtp"
 	"text/template"
@@ -62,12 +61,12 @@ func (sender *ProdSender) Ping() error {
 
 	err = conn.Auth(auth)
 	if err != nil {
-		return errors.Join(fmt.Errorf("authenticate with SMTP server: %w", err), conn.Close())
+		return fmt.Errorf("authenticate with SMTP server: %w", err)
 	}
 
 	err = conn.Quit()
 	if err != nil {
-		return errors.Join(fmt.Errorf("quit SMTP connection: %w", err), conn.Close())
+		return fmt.Errorf("quit SMTP connection: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Four unrelated bugs that came out of a review pass over `golib`. Each is its own commit — review per-commit.

## Bugs

1. **`smtp`: `ProdSender.Ping` double-closes the connection** — the `defer conn.Close()` at the top already covers the failure paths, but `errors.Join(..., conn.Close())` was tacked on too. Drop the inline closes.
2. **`httpf`: `SendJSON` drops the error message** — `lo.Ternary(err == nil, codes.Ok, codes.Error)` with an empty description meant a JSON-encode failure showed up as a generic `Error` status with no detail in the span. Switch to `otel.ReportError` / `otel.ReportSuccessNoContent` so `err.Error()` lands in the status. Also drops the only `samber/lo` import in `httpf`.
3. **`postgres`: `Ping` was a busy loop** — no sleep between failed `PingContext` attempts, so an unreachable DB got hammered for the whole 10s `PingTimeout`. Add a 100ms `PingRetryInterval` and respect ctx cancellation during the wait.
4. **`grpcf`: `SetEchoServers` leaks its health-toggle goroutine** — `for { ...; time.Sleep(healthPing) }` with no stop signal. Add `SetEchoServersContext(ctx, ...)` that exits cleanly when ctx is canceled; the legacy `SetEchoServers` delegates to it with `context.Background()` (byte-for-byte behavior preserved) and is now `// Deprecated:`.

## Consumer migration follow-ups (for #4)

Per `manage-versions` step 0: the `SetEchoServers` deprecation has **2 in-org consumers**, both `cmd/grpc/main.go`. The old function still works (delegates to the new one with `context.Background()`), so the migration is optional for compilation — but recommended to stop the goroutine leak on shutdown.

- [ ] `a-novel/service-json-keys` `cmd/grpc/main.go:114` — thread the main `ctx` through and swap to `grpcf.SetEchoServersContext(ctx, server, cfg.Grpc.Ping)`.
- [ ] `a-novel/service-template` `cmd/grpc/main.go:102` — same.

Each consumer PR re-pins `golib` to the released tag from this PR per `manage-versions`. Final removal of `SetEchoServers` happens in a later major-release PR once both consumers are migrated.

## Test plan

- [x] `make test` green locally
- [x] CI green