### PR TITLE
docs(deps): mark ResolveDependants as Deprecated (one-consumer cleanup)

### DIFF
--- a/deps/deps.go
+++ b/deps/deps.go
@@ -32,6 +32,12 @@ func printDepsGraph[Mod comparable](deps map[Mod]map[Mod]bool) string {
 //
 //	mod1 -> dep1, dep2
 //	mod2 -> dep3, dep1, dep2
+//
+// Deprecated: this helper has only a single consumer across the a-novel /
+// a-novel-kit org, which falls below the "several services would otherwise
+// copy it verbatim" bar for inclusion in golib. Inline it into the consumer
+// (currently service-authentication's `pkg/go/auth.go`) and the package will
+// be removed in a future release. See write-go-kit, "golib stays minimal".
 func ResolveDependants[Mod comparable, Deps any](mods map[Mod][]Deps, deps map[Mod][]Mod) (map[Mod][]Deps, error) {
 	// https://dnaeon.github.io/dependency-graph-resolution-algorithm-in-go/
 	// Convert dependencies to a map. The algorithm performs better using maps behavior.


### PR DESCRIPTION
Step 1 of the staged removal of `golib/deps`, per `manage-versions` (add deprecation → migrate consumers → remove).

## Why

`ResolveDependants` has exactly **one** consumer across the whole a-novel / a-novel-kit org:

```
$ grep -rn "ResolveDependants" app/ kit/ --include='*.go'
app/service-authentication/pkg/go/auth.go:48
```

That's below the kit-inclusion bar of "several services would otherwise copy it verbatim" (`write-go-kit`, "should this go in golib?"). One consumer is more naturally a private helper in that consumer's `internal/lib/`.

## What this PR does

- Adds a `// Deprecated:` doc comment to `ResolveDependants` pointing at the migration path.
- Leaves the function untouched otherwise — nothing breaks for the current consumer.

## Consumer migration follow-ups

Per `manage-versions` step 0: 1 in-org consumer.

- [ ] `a-novel/service-authentication` `pkg/go/auth.go:48` — inline `ResolveDependants` into `internal/lib/deps.go` (or wherever the file naturally lives), drop the import, re-pin `golib` to the released tag from this PR per `manage-versions`.
- [ ] After that consumer-side PR merges, a later golib release deletes the `deps` package entirely.

## Test plan

- [x] CI green (no code change — docs-only)