### PR TITLE
refactor(presets): drop fatih/color, consolidate on lipgloss

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.56.0
-	github.com/fatih/color v1.19.0
 	github.com/getsentry/sentry-go v0.46.2
 	github.com/getsentry/sentry-go/otel v0.46.2
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNf
 github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
-github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
-github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/getsentry/sentry-go v0.46.2 h1:1jhYwrKGa3sIpo/y5iDNXS5wDoT7I1KNzMHrnK6ojns=

--- a/logging/presets/grpc.local.go
+++ b/logging/presets/grpc.local.go
@@ -2,8 +2,8 @@ package loggingpresets
 
 import (
 	"log/slog"
+	"os"
 
-	"github.com/fatih/color"
 	grpclog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"google.golang.org/grpc"
@@ -48,6 +48,6 @@ func (logger *GrpcLocal) init() {
 		return
 	}
 
-	log := slog.New(slog.NewTextHandler(color.Output, &slog.HandlerOptions{}))
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
 	logger.l = log.With("service", "gRPC/server", "component", logger.Component)
 }

--- a/otel/presets/disabled.go
+++ b/otel/presets/disabled.go
@@ -3,6 +3,7 @@ package otelpresets
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"charm.land/lipgloss/v2"
 	"google.golang.org/grpc"
@@ -23,10 +24,11 @@ var _ otel.Config = (*Disabled)(nil)
 // Disabled configures Otel to disable traces & logs.
 type Disabled struct{}
 
-// Init just prints a banner for local dev mode.
+// Init prints a startup banner announcing that OpenTelemetry tracing and
+// logging are disabled.
 func (config *Disabled) Init() error {
 	banner := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
-	fmt.Println(banner.Render("🚀 OpenTelemetry Disabled Mode: no tracing"))
+	_, _ = fmt.Fprintln(os.Stdout, banner.Render("🚀 OpenTelemetry Disabled Mode: no tracing"))
 
 	return nil
 }

--- a/otel/presets/disabled.go
+++ b/otel/presets/disabled.go
@@ -1,9 +1,10 @@
 package otelpresets
 
 import (
+	"fmt"
 	"net/http"
 
-	"github.com/fatih/color"
+	"charm.land/lipgloss/v2"
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -24,8 +25,8 @@ type Disabled struct{}
 
 // Init just prints a banner for local dev mode.
 func (config *Disabled) Init() error {
-	green := color.New(color.FgGreen).Add(color.Bold)
-	_, _ = green.Println("🚀 OpenTelemetry Disabled Mode: no tracing")
+	banner := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+	fmt.Println(banner.Render("🚀 OpenTelemetry Disabled Mode: no tracing"))
 
 	return nil
 }

--- a/otel/presets/gcloud.go
+++ b/otel/presets/gcloud.go
@@ -37,7 +37,7 @@ type Gcloud struct {
 
 func (config *Gcloud) Init() error {
 	banner := lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
-	fmt.Println(banner.Render(fmt.Sprintf(
+	_, _ = fmt.Fprintln(os.Stdout, banner.Render(fmt.Sprintf(
 		"☁️ OpenTelemetry GCP Mode: exporting traces to Cloud Trace (project=%s)", config.ProjectID,
 	)))
 

--- a/otel/presets/gcloud.go
+++ b/otel/presets/gcloud.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"time"
 
+	"charm.land/lipgloss/v2"
 	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 	gcppropagator "github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator"
-	"github.com/fatih/color"
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -36,8 +36,10 @@ type Gcloud struct {
 }
 
 func (config *Gcloud) Init() error {
-	blue := color.New(color.FgBlue).Add(color.Bold)
-	_, _ = blue.Printf("☁️ OpenTelemetry GCP Mode: exporting traces to Cloud Trace (project=%s)\n", config.ProjectID)
+	banner := lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
+	fmt.Println(banner.Render(fmt.Sprintf(
+		"☁️ OpenTelemetry GCP Mode: exporting traces to Cloud Trace (project=%s)", config.ProjectID,
+	)))
 
 	return nil
 }

--- a/otel/presets/local.go
+++ b/otel/presets/local.go
@@ -37,7 +37,7 @@ type Local struct {
 // Init just prints a banner for local dev mode.
 func (config *Local) Init() error {
 	banner := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
-	fmt.Println(banner.Render("🚀 OpenTelemetry Local Mode: All traces and logs to stdout"))
+	_, _ = fmt.Fprintln(os.Stdout, banner.Render("🚀 OpenTelemetry Local Mode: All traces and logs to stdout"))
 
 	return nil
 }

--- a/otel/presets/local.go
+++ b/otel/presets/local.go
@@ -2,11 +2,13 @@ package otelpresets
 
 import (
 	"context"
+	"fmt"
 	stdlog "log"
 	"net/http"
+	"os"
 	"time"
 
-	"github.com/fatih/color"
+	"charm.land/lipgloss/v2"
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -34,8 +36,8 @@ type Local struct {
 
 // Init just prints a banner for local dev mode.
 func (config *Local) Init() error {
-	green := color.New(color.FgGreen).Add(color.Bold)
-	_, _ = green.Println("🚀 OpenTelemetry Local Mode: All traces and logs to stdout")
+	banner := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+	fmt.Println(banner.Render("🚀 OpenTelemetry Local Mode: All traces and logs to stdout"))
 
 	return nil
 }
@@ -47,7 +49,7 @@ func (config *Local) GetPropagators() (propagation.TextMapPropagator, error) {
 func (config *Local) GetTraceProvider() (trace.TracerProvider, error) {
 	traceExporter, err := stdouttrace.New(
 		stdouttrace.WithPrettyPrint(),
-		stdouttrace.WithWriter(color.Output), // writes with color support
+		stdouttrace.WithWriter(os.Stdout),
 	)
 	if err != nil {
 		return nil, err
@@ -64,7 +66,7 @@ func (config *Local) GetTraceProvider() (trace.TracerProvider, error) {
 func (config *Local) GetLogger() (log.LoggerProvider, error) {
 	logExporter, err := stdoutlog.New(
 		stdoutlog.WithPrettyPrint(),
-		stdoutlog.WithWriter(color.Output),
+		stdoutlog.WithWriter(os.Stdout),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
golib carried two terminal-styling dependencies side by side: `github.com/fatih/color` (otel/presets banners + one slog text handler) and `charm.land/lipgloss/v2` (the rest of logging/presets). One ANSI-styling lib is enough — `lipgloss` is already a direct dep and the shared `LipColor*` constants are already in `logging/presets/utils.go`.

## What changed

| File | Change |
|---|---|
| `otel/presets/{disabled,local,gcloud}.go` | Banner prints now use `lipgloss.NewStyle().Foreground(...).Bold(true).Render(...)` + `fmt.Println`. ANSI 10 (bright green) for Disabled/Local, 12 (bright blue) for Gcloud — same intent as before. |
| `otel/presets/local.go` | `stdouttrace.WithWriter(color.Output)` / `stdoutlog.WithWriter(color.Output)` → `os.Stdout`. The exporters emit JSON/text; `color.Output` was only there for Windows ANSI handling, which lipgloss handles via colorprofile when it actually renders. |
| `logging/presets/grpc.local.go` | `slog.NewTextHandler(color.Output, ...)` → `slog.NewTextHandler(os.Stdout, ...)` for the same reason. |
| `go.mod` / `go.sum` | `go mod tidy` drops `fatih/color` and its `mattn/go-colorable` transitive. |

## Why this is non-breaking

No public API change. The visible difference is a slightly different ANSI rendering of the three startup banners; consumers don't pin behaviour to those exact escape codes.

## Test plan

- [x] `go build ./...` clean
- [x] `make test` green (29 tests)
- [ ] CI green