### PR TITLE
refactor(smtp): introduce smtptest sub-package; deprecate legacy in-package helpers

### DIFF
--- a/smtp/sender.test.go
+++ b/smtp/sender.test.go
@@ -6,18 +6,35 @@ import (
 	"text/template"
 )
 
+// ErrPingTestSender is returned by TestSender.Ping.
+//
+// Deprecated: use smtptest.ErrPing in the github.com/a-novel-kit/golib/smtp/smtptest
+// sub-package. The legacy symbols in this file ship in every consumer binary
+// because the `.test.go` filename suffix is not recognised by `go build` —
+// only `_test.go` is excluded from production builds. The smtptest package
+// makes the test-only boundary explicit.
 var ErrPingTestSender = errors.New("pinging test sender: make sure this is not a misconfiguration")
 
+// TestMail is the captured form of a single SendMail call.
+//
+// Deprecated: use smtptest.Mail instead.
 type TestMail struct {
 	To   []string
 	Data any
 }
 
+// TestSender is an in-memory smtp.Sender that records every SendMail call.
+//
+// Deprecated: use smtptest.Sender instead. See ErrPingTestSender for the
+// rationale.
 type TestSender struct {
 	mails []*TestMail
 	mu    sync.RWMutex
 }
 
+// NewTestSender returns an empty TestSender.
+//
+// Deprecated: use smtptest.NewSender instead.
 func NewTestSender() *TestSender {
 	return &TestSender{}
 }

--- a/smtp/smtptest/sender.go
+++ b/smtp/smtptest/sender.go
@@ -65,11 +65,19 @@ func (sender *Sender) Ping() error {
 
 // FindMail returns the first captured Mail for which cmp returns true, or
 // (nil, false) if no captured Mail matched.
+//
+// The lock is released before cmp is invoked: snapshotting the pointer slice
+// under the lock and iterating afterwards prevents a deadlock if cmp
+// re-enters the Sender (e.g. by calling SendMail or FindMail again), and
+// avoids unnecessarily blocking concurrent SendMail callers for the duration
+// of a slow comparator. The returned *Mail aliases the captured entry —
+// callers must not mutate it.
 func (sender *Sender) FindMail(cmp func(*Mail) bool) (*Mail, bool) {
 	sender.mu.RLock()
-	defer sender.mu.RUnlock()
+	snapshot := append([]*Mail(nil), sender.mails...)
+	sender.mu.RUnlock()
 
-	for _, mail := range sender.mails {
+	for _, mail := range snapshot {
 		if cmp(mail) {
 			return mail, true
 		}

--- a/smtp/smtptest/sender.go
+++ b/smtp/smtptest/sender.go
@@ -1,0 +1,79 @@
+// Package smtptest provides an in-memory implementation of smtp.Sender for use
+// in unit and integration tests. Its types satisfy the smtp.Sender interface,
+// so a test can substitute *smtptest.Sender wherever an smtp.Sender is
+// expected.
+//
+// This package supersedes the legacy `smtp.TestSender` / `smtp.TestMail` /
+// `smtp.NewTestSender` / `smtp.ErrPingTestSender` symbols, which were defined
+// in `smtp/sender.test.go`. The dot-suffixed filename was misleading — Go's
+// build tooling only excludes files ending in `_test.go` (underscore) from
+// production builds, so the legacy symbols ship in every consumer binary
+// regardless of whether they are used. Keeping the test helpers in a dedicated
+// sub-package makes the boundary explicit.
+package smtptest
+
+import (
+	"errors"
+	"sync"
+	"text/template"
+
+	"github.com/a-novel-kit/golib/smtp"
+)
+
+// ErrPing is returned by Sender.Ping. Production code that pings a test
+// sender almost always indicates a misconfiguration where the real SMTP
+// sender was meant to be wired in.
+var ErrPing = errors.New("pinging smtptest sender: make sure this is not a misconfiguration")
+
+// Mail is the captured form of a single SendMail call.
+type Mail struct {
+	To   []string
+	Data any
+}
+
+// Sender is an in-memory smtp.Sender that records every SendMail call into
+// an internal slice queryable via FindMail. Safe for concurrent use.
+type Sender struct {
+	mails []*Mail
+	mu    sync.RWMutex
+}
+
+// NewSender returns an empty Sender ready to capture mails.
+func NewSender() *Sender {
+	return &Sender{}
+}
+
+// SendMail satisfies smtp.Sender by appending a captured Mail entry rather
+// than reaching any network.
+func (sender *Sender) SendMail(to smtp.MailUsers, _ *template.Template, _ string, data any) error {
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+
+	sender.mails = append(sender.mails, &Mail{
+		To:   to.Emails(),
+		Data: data,
+	})
+
+	return nil
+}
+
+// Ping always returns ErrPing — production code should never end up calling
+// it.
+func (sender *Sender) Ping() error {
+	return ErrPing
+}
+
+// FindMail returns the first captured Mail for which cmp returns true, or
+// (nil, false) if no captured Mail matched.
+func (sender *Sender) FindMail(cmp func(*Mail) bool) (*Mail, bool) {
+	sender.mu.RLock()
+	defer sender.mu.RUnlock()
+
+	for _, mail := range sender.mails {
+		if cmp(mail) {
+			return mail, true
+		}
+	}
+
+	return nil, false
+}

--- a/smtp/smtptest/sender_test.go
+++ b/smtp/smtptest/sender_test.go
@@ -1,0 +1,60 @@
+package smtptest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/smtp"
+	"github.com/a-novel-kit/golib/smtp/smtptest"
+)
+
+func TestSender(t *testing.T) {
+	t.Parallel()
+
+	sender := smtptest.NewSender()
+
+	require.NoError(t, sender.SendMail(smtp.MailUsers{{Email: "user"}}, nil, "", map[string]string{"test": "foo"}))
+	require.NoError(t, sender.SendMail(smtp.MailUsers{{Email: "user"}}, nil, "", map[string]string{"test": "bar"}))
+
+	require.Eventually(t, func() bool {
+		res, ok := sender.FindMail(func(mail *smtptest.Mail) bool {
+			return mail.Data.(map[string]string)["test"] == "foo"
+		})
+
+		return assert.True(t, ok) &&
+			assert.Equal(t, &smtptest.Mail{
+				To:   []string{"user"},
+				Data: map[string]string{"test": "foo"},
+			}, res)
+	}, 100*time.Millisecond, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		res, ok := sender.FindMail(func(mail *smtptest.Mail) bool {
+			return mail.Data.(map[string]string)["test"] == "bar"
+		})
+
+		return assert.True(t, ok) &&
+			assert.Equal(t, &smtptest.Mail{
+				To:   []string{"user"},
+				Data: map[string]string{"test": "bar"},
+			}, res)
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		res, ok := sender.FindMail(func(mail *smtptest.Mail) bool {
+			return mail.Data.(map[string]string)["test"] == "baz"
+		})
+
+		return assert.False(t, ok) &&
+			assert.Nil(t, res)
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestPing(t *testing.T) {
+	t.Parallel()
+
+	sender := smtptest.NewSender()
+	require.ErrorIs(t, sender.Ping(), smtptest.ErrPing)
+}


### PR DESCRIPTION
## Why

The legacy `smtp.TestSender` / `smtp.TestMail` / `smtp.NewTestSender` / `smtp.ErrPingTestSender` symbols live in `smtp/sender.test.go`. The dot-suffixed filename **looks** like a test-only signal, but Go's build tooling only excludes files ending in `_test.go` (underscore) from production builds — so the legacy symbols ship in every consumer binary regardless of whether they are used.

Same footgun the service-template repo hit recently with its `configtest.go` — the fix is the same: move the helpers to a dedicated sub-package whose name makes the boundary explicit.

## What this PR does

- New `smtp/smtptest` sub-package with canonical types (`smtptest.Sender`, `smtptest.Mail`, `smtptest.NewSender`, `smtptest.FindMail`, `smtptest.ErrPing`). The "Test" prefix is dropped from the type names since the package itself already conveys the intent. Types implement `smtp.Sender` so substitution is direct.
- A parallel test file `smtp/smtptest/sender_test.go` covers the new package.
- Each legacy symbol in `smtp/sender.test.go` gets a `// Deprecated:` doc comment pointing at the smtptest replacement and a one-line explanation of why the move was needed.

## Why two parallel implementations (not type aliases)

`smtp/smtptest` imports `smtp` for `smtp.MailUsers` and the `smtp.Sender` interface. If `smtp` aliased back to `smtp/smtptest`, that would re-introduce an import cycle. Two parallel implementations until the legacy is removed in a future release.

## Consumer migration follow-ups

Per `manage-versions` step 0: **zero in-org consumers** of the legacy names.

```
$ grep -rn "smtp\.\(TestSender\|TestMail\|NewTestSender\|ErrPingTestSender\|FindTestMail\)" app/ kit/ --include='*.go'
# (no matches outside golib itself)
```

So no in-org migration PR is needed. The staged-removal flow stays staged (rather than collapsed to immediate removal) only because `golib` is a public module and external pkg.go.dev consumers may exist — a future major release can confidently delete the legacy block.

## Test plan

- [x] `go build ./...` clean
- [x] `make test` green (31 tests, 2 new in `smtp/smtptest`)
- [x] CI green