### PR TITLE
refactor(logging): add HTTPConfig / RPCConfig / HTTP* / GRPC* aliases (acronym casing)

### DIFF
--- a/logging/http.go
+++ b/logging/http.go
@@ -4,6 +4,14 @@ import (
 	"net/http"
 )
 
-type HttpConfig interface {
+// HTTPConfig is implemented by anything that produces an HTTP middleware
+// chain emitting structured access logs.
+type HTTPConfig interface {
 	Logger() func(http.Handler) http.Handler
 }
+
+// HttpConfig is the legacy spelling of HTTPConfig.
+//
+// Deprecated: use HTTPConfig. The renamed alias matches the project's
+// acronym-casing convention (`HTTP`, not `Http`); behaviour is unchanged.
+type HttpConfig = HTTPConfig

--- a/logging/presets/grpc.gcloud.go
+++ b/logging/presets/grpc.gcloud.go
@@ -11,39 +11,39 @@ import (
 	"github.com/a-novel-kit/golib/logging"
 )
 
-var _ logging.RpcConfig = (*GrpcGcloud)(nil)
+var _ logging.RPCConfig = (*GRPCGcloud)(nil)
 
-type GrpcGcloud struct {
+type GRPCGcloud struct {
 	Component string `json:"component" yaml:"component"`
 
 	l *slog.Logger
 }
 
-func (logger *GrpcGcloud) UnaryInterceptor() grpc.UnaryServerInterceptor {
+func (logger *GRPCGcloud) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	logger.init()
 
 	return grpclog.UnaryServerInterceptor(logInterceptor(logger.l), grpclog.WithFieldsFromContext(logTraceId))
 }
 
-func (logger *GrpcGcloud) StreamInterceptor() grpc.StreamServerInterceptor {
+func (logger *GRPCGcloud) StreamInterceptor() grpc.StreamServerInterceptor {
 	logger.init()
 
 	return grpclog.StreamServerInterceptor(logInterceptor(logger.l), grpclog.WithFieldsFromContext(logTraceId))
 }
 
-func (logger *GrpcGcloud) PanicUnaryInterceptor() grpc.UnaryServerInterceptor {
+func (logger *GRPCGcloud) PanicUnaryInterceptor() grpc.UnaryServerInterceptor {
 	logger.init()
 
 	return recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(panicInterceptor(logger.l)))
 }
 
-func (logger *GrpcGcloud) PanicStreamInterceptor() grpc.StreamServerInterceptor {
+func (logger *GRPCGcloud) PanicStreamInterceptor() grpc.StreamServerInterceptor {
 	logger.init()
 
 	return recovery.StreamServerInterceptor(recovery.WithRecoveryHandler(panicInterceptor(logger.l)))
 }
 
-func (logger *GrpcGcloud) init() {
+func (logger *GRPCGcloud) init() {
 	if logger.l != nil {
 		return
 	}
@@ -51,3 +51,10 @@ func (logger *GrpcGcloud) init() {
 	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{}))
 	logger.l = log.With("service", "gRPC/server", "component", logger.Component)
 }
+
+// GrpcGcloud is the legacy spelling of GRPCGcloud.
+//
+// Deprecated: use GRPCGcloud. The renamed alias matches the project's
+// acronym-casing convention (`gRPC`/`GRPC`, not `Grpc`); behaviour is
+// unchanged.
+type GrpcGcloud = GRPCGcloud

--- a/logging/presets/grpc.local.go
+++ b/logging/presets/grpc.local.go
@@ -11,39 +11,39 @@ import (
 	"github.com/a-novel-kit/golib/logging"
 )
 
-var _ logging.RpcConfig = (*GrpcLocal)(nil)
+var _ logging.RPCConfig = (*GRPCLocal)(nil)
 
-type GrpcLocal struct {
+type GRPCLocal struct {
 	Component string `json:"component" yaml:"component"`
 
 	l *slog.Logger
 }
 
-func (logger *GrpcLocal) UnaryInterceptor() grpc.UnaryServerInterceptor {
+func (logger *GRPCLocal) UnaryInterceptor() grpc.UnaryServerInterceptor {
 	logger.init()
 
 	return grpclog.UnaryServerInterceptor(logInterceptor(logger.l), grpclog.WithFieldsFromContext(logTraceId))
 }
 
-func (logger *GrpcLocal) StreamInterceptor() grpc.StreamServerInterceptor {
+func (logger *GRPCLocal) StreamInterceptor() grpc.StreamServerInterceptor {
 	logger.init()
 
 	return grpclog.StreamServerInterceptor(logInterceptor(logger.l), grpclog.WithFieldsFromContext(logTraceId))
 }
 
-func (logger *GrpcLocal) PanicUnaryInterceptor() grpc.UnaryServerInterceptor {
+func (logger *GRPCLocal) PanicUnaryInterceptor() grpc.UnaryServerInterceptor {
 	logger.init()
 
 	return recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(panicInterceptor(logger.l)))
 }
 
-func (logger *GrpcLocal) PanicStreamInterceptor() grpc.StreamServerInterceptor {
+func (logger *GRPCLocal) PanicStreamInterceptor() grpc.StreamServerInterceptor {
 	logger.init()
 
 	return recovery.StreamServerInterceptor(recovery.WithRecoveryHandler(panicInterceptor(logger.l)))
 }
 
-func (logger *GrpcLocal) init() {
+func (logger *GRPCLocal) init() {
 	if logger.l != nil {
 		return
 	}
@@ -51,3 +51,10 @@ func (logger *GrpcLocal) init() {
 	log := slog.New(slog.NewTextHandler(color.Output, &slog.HandlerOptions{}))
 	logger.l = log.With("service", "gRPC/server", "component", logger.Component)
 }
+
+// GrpcLocal is the legacy spelling of GRPCLocal.
+//
+// Deprecated: use GRPCLocal. The renamed alias matches the project's
+// acronym-casing convention (`gRPC`/`GRPC`, not `Grpc`); behaviour is
+// unchanged.
+type GrpcLocal = GRPCLocal

--- a/logging/presets/http.gcloud.go
+++ b/logging/presets/http.gcloud.go
@@ -16,13 +16,13 @@ import (
 	"github.com/a-novel-kit/golib/otel/utils"
 )
 
-var _ logging.HttpConfig = (*HttpGcloud)(nil)
+var _ logging.HTTPConfig = (*HTTPGcloud)(nil)
 
-type HttpGcloud struct {
+type HTTPGcloud struct {
 	BaseLogger *LogGcloud
 }
 
-func (logger *HttpGcloud) Logger() func(http.Handler) http.Handler {
+func (logger *HTTPGcloud) Logger() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx, span := libotel.Tracer().Start(r.Context(), fmt.Sprintf("[%s] %s.%s", r.Method, r.Host, r.URL.Path))
@@ -89,3 +89,9 @@ func (logger *HttpGcloud) Logger() func(http.Handler) http.Handler {
 		})
 	}
 }
+
+// HttpGcloud is the legacy spelling of HTTPGcloud.
+//
+// Deprecated: use HTTPGcloud. The renamed alias matches the project's
+// acronym-casing convention (`HTTP`, not `Http`); behaviour is unchanged.
+type HttpGcloud = HTTPGcloud

--- a/logging/presets/http.local.go
+++ b/logging/presets/http.local.go
@@ -12,13 +12,13 @@ import (
 	"github.com/a-novel-kit/golib/otel/utils"
 )
 
-var _ logging.HttpConfig = (*HttpLocal)(nil)
+var _ logging.HTTPConfig = (*HTTPLocal)(nil)
 
-type HttpLocal struct {
+type HTTPLocal struct {
 	BaseLogger *LogLocal
 }
 
-func (logger *HttpLocal) Logger() func(http.Handler) http.Handler {
+func (logger *HTTPLocal) Logger() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			wrapped := &utils.CaptureHTTPResponseWriter{ResponseWriter: w}
@@ -69,3 +69,9 @@ func (logger *HttpLocal) Logger() func(http.Handler) http.Handler {
 		})
 	}
 }
+
+// HttpLocal is the legacy spelling of HTTPLocal.
+//
+// Deprecated: use HTTPLocal. The renamed alias matches the project's
+// acronym-casing convention (`HTTP`, not `Http`); behaviour is unchanged.
+type HttpLocal = HTTPLocal

--- a/logging/rpc.go
+++ b/logging/rpc.go
@@ -2,8 +2,9 @@ package logging
 
 import "google.golang.org/grpc"
 
-// RPCConfig is implemented by anything that produces gRPC interceptors
-// emitting structured access logs (and a panic recovery handler).
+// RPCConfig is implemented by anything that produces gRPC interceptors —
+// both for emitting structured access logs (Unary/Stream Interceptor) and
+// for recovering from handler panics (PanicUnary/PanicStream Interceptor).
 type RPCConfig interface {
 	UnaryInterceptor() grpc.UnaryServerInterceptor
 	StreamInterceptor() grpc.StreamServerInterceptor

--- a/logging/rpc.go
+++ b/logging/rpc.go
@@ -2,9 +2,17 @@ package logging
 
 import "google.golang.org/grpc"
 
-type RpcConfig interface {
+// RPCConfig is implemented by anything that produces gRPC interceptors
+// emitting structured access logs (and a panic recovery handler).
+type RPCConfig interface {
 	UnaryInterceptor() grpc.UnaryServerInterceptor
 	StreamInterceptor() grpc.StreamServerInterceptor
 	PanicUnaryInterceptor() grpc.UnaryServerInterceptor
 	PanicStreamInterceptor() grpc.StreamServerInterceptor
 }
+
+// RpcConfig is the legacy spelling of RPCConfig.
+//
+// Deprecated: use RPCConfig. The renamed alias matches the project's
+// acronym-casing convention (`RPC`, not `Rpc`); behaviour is unchanged.
+type RpcConfig = RPCConfig


### PR DESCRIPTION
## Why

The project's Go-conventions skill (`write-go`) calls out the acronym-casing rule: `HTTP`, `REST`, `gRPC`/`GRPC`, `SQL`, `ID`, `URL` etc. stay in their ecosystem casing — `HTTPConfig`, not `HttpConfig`. golib was inconsistent: the exported types `logging.HttpConfig` / `logging.RpcConfig` and the four preset structs all used mixed-case Go spelling.

## What changed

Pure type renames are aliasable, so this PR does the additive step of the staged removal per `manage-versions`:

| Old | New |
|---|---|
| `logging.HttpConfig` | `logging.HTTPConfig` |
| `logging.RpcConfig` | `logging.RPCConfig` |
| `loggingpresets.HttpLocal` | `loggingpresets.HTTPLocal` |
| `loggingpresets.HttpGcloud` | `loggingpresets.HTTPGcloud` |
| `loggingpresets.GrpcLocal` | `loggingpresets.GRPCLocal` |
| `loggingpresets.GrpcGcloud` | `loggingpresets.GRPCGcloud` |

Each legacy name remains as a `// Deprecated:` type alias pointing at the new name. Composite-literal call sites (`loggingpresets.HttpLocal{BaseLogger: ...}`) keep working byte-for-byte; only godoc shows the deprecation. The in-package `var _ logging.HttpConfig = (*HTTPLocal)(nil)` conformance asserts are updated to use the new interface names directly.

## Consumer migration follow-ups

Per `manage-versions` step 0: **4 in-org consumers** across both type references (HttpConfig/RpcConfig) and composite literals (HttpLocal/HttpGcloud/GrpcLocal/GrpcGcloud). The old names still work via type aliases, so the migration is purely cosmetic / godoc-warning-clearing, not load-bearing.

- [ ] `a-novel/service-authentication` — `internal/config/app.config.go:57` (`HttpConfig` field type), `internal/config/app.config.default.go:90, 92, 95` (`HttpConfig` generic type-param + `HttpLocal` + `HttpGcloud` literals).
- [ ] `a-novel/service-json-keys` — `internal/config/app.config.go:71, 73` (`RpcConfig`, `HttpConfig`), `internal/config/app.config.default.go:24, 29, 78, 79, 81, 82` (the four legacy types + generic params).
- [ ] `a-novel/service-template` — `internal/config/app.config.go:61, 62` (`RpcConfig`, `HttpConfig`), `internal/config/app.config.default.go:22, 27, 74, 75, 77, 78` (the four legacy types + generic params).
- [ ] `a-novel/service-narrative-engine` — `internal/config/app.config.go:56` (`HttpConfig`), `internal/config/app.config.default.go:75, 77, 80` (`HttpConfig` + `HttpLocal` + `HttpGcloud`).

Each consumer PR re-pins `golib` to the released tag from this PR per `manage-versions`. Final removal of the legacy aliases happens in a later major-release PR once all four consumers are migrated.

## Out of scope (deferred to a major release)

Not all acronym-casing violations are aliasable:

- **Interface method names** — `HttpHandler()` / `RpcInterceptor()` on `otel.Config`. Renaming a method breaks every implementation, and Go has no method alias.
- **Struct field names** — `smtp.ProdSender.ForceUnencryptedTls`, `LogGcloud.ProjectId`. Renaming a field breaks struct literals.

Both will need a coordinated major-version cycle.

## Test plan

- [x] `go build ./...` clean
- [x] `make test` green (29 tests)
- [x] CI green