### PR TITLE
ci: add publish:patch for security-update auto-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "pnpm lint:go && pnpm lint:proto && pnpm lint:prettier",
     "lint:go": "go tool -modfile=golangci-lint.mod golangci-lint run ./...",
     "lint:prettier": "prettier --check . --config prettier.config.js",
-    "lint:proto": "go tool buf lint"
+    "lint:proto": "go tool buf lint",
+    "publish:patch": "pnpm version patch && git push --follow-tags"
   },
   "devDependencies": {
     "prettier": "^3.6.2",


### PR DESCRIPTION
The scheduled `security-update` workflow fails:

```
$ pnpm run publish:patch
[ERR_PNPM_NO_SCRIPT] Missing script: publish:patch
```

`node-actions/security-update` calls `pnpm run publish:patch` to cut a patch release when the default branch has unreleased commits (e.g. after `node-audit` commits an advisory fix). The script was removed in the publish-CLI migration, so the bot can't release.

Restore it with the same shape jwt uses — bump the version, push the commit + tag so `release.yaml` fires:

```
"publish:patch": "pnpm version patch && git push --follow-tags"
```

Note: this only succeeds once the publish bot can push to the default branch — it's blocked today by the codecov ruleset (fixed in a-novel-kit/stack#81, applied per-repo via `a-novel repo update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)