### PR TITLE
docs: trim prose, keep capability/rule lists in their own sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@ For platform-wide setup (Go, Node, Podman, the `a-novel` CLI) and the day-to-day
 
 ## The bar for additions
 
-`golib` is intentionally minimal — it holds only the cross-cutting glue that the backend services would otherwise copy between repos. Before adding to it, weigh the addition against this bar:
+`golib` stays small on purpose — it holds only the glue two or more services would otherwise copy between repos. Weigh any addition against three questions:
 
-- **A well-maintained library already does it?** Use that library directly; do not wrap it here.
-- **Only one service needs it?** Keep it in that service until a second one does.
-- **It has grown a broad public API of its own?** It should graduate into its own repo rather than live as a `golib` sub-package — the [`jwt`](https://github.com/a-novel-kit/jwt) package is the precedent.
+- Does a well-maintained library already do it? Use that library; don't wrap it here.
+- Does only one service need it? Keep it there until a second one does.
+- Has it grown a broad public API of its own? Graduate it into its own repo, like [`jwt`](https://github.com/a-novel-kit/jwt) did.
 
-Good additions are small, dependency-light helpers that at least two services share and that no upstream library covers cleanly.
+The sweet spot is a small, dependency-light helper that several services share and nothing upstream covers cleanly.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go lib
 
-The minimal shared Go library for A-Novel backend services — the cross-cutting glue (env parsing, OpenTelemetry, Postgres, REST/gRPC helpers) that would otherwise be copied repo to repo.
+The minimal shared Go library for A-Novel backend services — the cross-cutting glue they would otherwise copy between repos.
 
 [![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/agorastoryverse)](https://twitter.com/agorastoryverse)
 [![Discord](https://img.shields.io/discord/1315240114691248138?logo=discord)](https://discord.gg/rp4Qr8cA)
@@ -16,7 +16,7 @@ The minimal shared Go library for A-Novel backend services — the cross-cutting
 
 ## What this is
 
-`golib` collects the small amount of cross-cutting glue that the A-Novel backend services would otherwise copy from one repo to the next — env-variable parsing, OpenTelemetry plumbing, Postgres + bun helpers, REST and gRPC boundary utilities, shared logging interfaces, and an SMTP sender. It is **not** a framework and is deliberately kept as small as possible: anything a well-maintained library already covers belongs in that library, not here. When a sub-package outgrows the "boilerplate" bar and earns a broader public API, it graduates into its own repo — the [`jwt`](https://github.com/a-novel-kit/jwt) package is the precedent.
+`golib` collects the cross-cutting glue that the A-Novel backend services would otherwise copy from one repo to the next. It is **not** a framework and is kept deliberately small: anything a well-maintained library already covers belongs there, not here. When a sub-package grows a broad public API of its own, it graduates into its own repo — [`jwt`](https://github.com/a-novel-kit/jwt) is the precedent.
 
 The full API reference lives on [**pkg.go.dev**](https://pkg.go.dev/github.com/a-novel-kit/golib); godoc is canonical and this README only points at it.
 
@@ -40,4 +40,4 @@ go get github.com/a-novel-kit/golib
 
 ## Contributing
 
-Platform setup and the day-to-day commands live in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); `golib`-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md). The bar for additions is deliberately high — convenience wrappers around well-maintained dependencies, and one-off helpers only one service needs, do not belong here.
+Platform setup and the day-to-day commands live in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); `golib`-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
Follow-up to the docs standardization. Two editorial fixes (applied fleet-wide in sibling PRs):

- **No inline enumerations in explanatory prose.** "What this is" (and the title description) no longer list every capability inline — that list lives once, in the `## Sub-packages` table. Inlining it broke reading rhythm and created a second place to maintain.
- **Contribution rules live in CONTRIBUTING only.** The README Contributing section is now just the two links; the "bar for additions" rule moved to `CONTRIBUTING.md` and reads more naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)