### PR TITLE
docs: tighten prose — shorter sentences, leaner tables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,17 @@
 # Contributing to golib
 
-For platform-wide setup (Go, Node, Podman, the `a-novel` CLI) and the day-to-day commands, see the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file documents what is specific to `golib`.
+Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file covers what's specific to `golib`.
 
 ## The bar for additions
 
-`golib` stays small on purpose — it holds only the glue two or more services would otherwise copy between repos. Weigh any addition against three questions:
+`golib` stays small on purpose. Weigh any addition against three questions:
 
 - Does a well-maintained library already do it? Use that library; don't wrap it here.
 - Does only one service need it? Keep it there until a second one does.
-- Has it grown a broad public API of its own? Graduate it into its own repo, like [`jwt`](https://github.com/a-novel-kit/jwt) did.
+- Has it grown a broad API of its own? Graduate it to its own repo, like [`jwt`](https://github.com/a-novel-kit/jwt) did.
 
-The sweet spot is a small, dependency-light helper that several services share and nothing upstream covers cleanly.
+The sweet spot: a small, dependency-light helper several services share that nothing upstream covers cleanly.
 
 ## Questions?
 
-- Open an issue at https://github.com/a-novel-kit/golib/issues
-- Check existing issues for similar problems
-- Include relevant logs and environment details
+[Open an issue](https://github.com/a-novel-kit/golib/issues) — include logs and environment details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go lib
 
-The minimal shared Go library for A-Novel backend services — the cross-cutting glue they would otherwise copy between repos.
+Shared Go library for the A-Novel backend services — the glue they'd otherwise copy between repos.
 
 [![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/agorastoryverse)](https://twitter.com/agorastoryverse)
 [![Discord](https://img.shields.io/discord/1315240114691248138?logo=discord)](https://discord.gg/rp4Qr8cA)
@@ -16,9 +16,9 @@ The minimal shared Go library for A-Novel backend services — the cross-cutting
 
 ## What this is
 
-`golib` collects the cross-cutting glue that the A-Novel backend services would otherwise copy from one repo to the next. It is **not** a framework and is kept deliberately small: anything a well-maintained library already covers belongs there, not here. When a sub-package grows a broad public API of its own, it graduates into its own repo — [`jwt`](https://github.com/a-novel-kit/jwt) is the precedent.
+Not a framework, and small on purpose: if a well-maintained library already covers it, it doesn't live here. A sub-package that grows a broad API of its own graduates to its own repo, as [`jwt`](https://github.com/a-novel-kit/jwt) did.
 
-The full API reference lives on [**pkg.go.dev**](https://pkg.go.dev/github.com/a-novel-kit/golib); godoc is canonical and this README only points at it.
+godoc on [pkg.go.dev](https://pkg.go.dev/github.com/a-novel-kit/golib) is the full reference.
 
 ## Installation
 
@@ -28,16 +28,16 @@ go get github.com/a-novel-kit/golib
 
 ## Sub-packages
 
-| Path       | What it covers                                                                                                                                                               |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `config`   | `LoadEnv[T]` + a set of `strconv`-shaped parsers for environment variables; `Must` / `MustUnmarshal` panic-on-error helpers for one-shot startup wiring.                     |
-| `otel`     | `Tracer` / `Logger` accessors keyed on a shared `AppName`, the `ReportError` / `ReportSuccess` span helpers, and a `Config` interface implemented by `otel/presets/*`.       |
-| `httpf`    | `HandleError(errMap)` for mapping sentinels onto HTTP status codes (and reporting them on the request span); `SendJSON` for the success path.                                |
-| `grpcf`    | `BaseContext*Interceptor` for per-call context shaping, a `CredentialsProvider` interface with local / GCP implementations, and a built-in echo + health-check demo service. |
-| `logging`  | The shared `Log` / `HTTPConfig` / `RPCConfig` interfaces; concrete implementations live in `logging/presets/*` (local and GCP variants for both HTTP and gRPC).              |
-| `postgres` | `bun.IDB`-on-context plumbing (`NewContext`, `GetContext`, `RunInTx`), the migrations runner, the `PassthroughTx` test wrapper, and `RunTransactionalTest` / -`Isolated`.    |
-| `smtp`     | `Sender` interface with `ProdSender` (real SMTP) and `DebugSender` (writes to an `io.Writer`); the in-memory test helper lives in `smtp/smtptest`.                           |
+| Path       | What it covers                                                                          |
+| ---------- | --------------------------------------------------------------------------------------- |
+| `config`   | Typed env-var loading (`LoadEnv[T]`) and panic-on-error startup helpers.                |
+| `otel`     | OpenTelemetry tracer/logger access and span error reporting; local and GCP presets.     |
+| `httpf`    | REST boundary: map error sentinels to HTTP statuses, send JSON.                         |
+| `grpcf`    | gRPC boundary: context interceptors, local/GCP credentials, a demo echo/health service. |
+| `logging`  | Shared logging interfaces, with local and GCP presets for HTTP and gRPC.                |
+| `postgres` | Context-scoped `bun` DB, transactions, a migrations runner, and test harnesses.         |
+| `smtp`     | An SMTP `Sender` (prod and debug) and an in-memory test helper.                         |
 
 ## Contributing
 
-Platform setup and the day-to-day commands live in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); `golib`-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md).
+Setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); golib-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Shared Go library for the A-Novel backend services — the glue they'd otherwise
 
 Not a framework, and small on purpose: if a well-maintained library already covers it, it doesn't live here. A sub-package that grows a broad API of its own graduates to its own repo, as [`jwt`](https://github.com/a-novel-kit/jwt) did.
 
-godoc on [pkg.go.dev](https://pkg.go.dev/github.com/a-novel-kit/golib) is the full reference.
+Full reference: godoc on [pkg.go.dev](https://pkg.go.dev/github.com/a-novel-kit/golib).
 
 ## Installation
 


### PR DESCRIPTION
A further concision pass on the docs. These edits were originally pushed onto #307's branch *after* #307 had already merged, so no PR captured them — re-opened cleanly here off current `master`.

- "What this is" leads with the philosophy instead of restating the one-line description.
- Sub-packages cells describe what each covers in a line, not an export-by-export list.
- "Questions?" trimmed to one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)