### PR TITLE
docs: link concepts doc + formalize graduation, define sub-package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to golib
 
-Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file covers what's specific to `golib`.
+The library taxonomy — what a library is, the aggregated-vs-graduated split, and the public-package obligations a graduated package takes on — lives in the [libraries, tooling & platform concepts](https://github.com/a-novel-kit/.github/blob/master/CONTRIBUTING.md); this file covers what's specific to `golib`. Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md).
 
 ## The bar for additions
 
@@ -8,7 +8,7 @@ Platform setup and day-to-day commands are in the [developer onboarding guide](h
 
 - Does a well-maintained library already do it? Use that library; don't wrap it here.
 - Does only one service need it? Keep it there until a second one does.
-- Has it grown a broad API of its own? Graduate it to its own repo, like [`jwt`](https://github.com/a-novel-kit/jwt) did.
+- Has it grown a broad API of its own? Then it [graduates](https://github.com/a-novel-kit/.github/blob/master/CONTRIBUTING.md#libraries) to its own repo, like [`jwt`](https://github.com/a-novel-kit/jwt) did — taking on the public-package obligations that come with standing alone: its own README/CONTRIBUTING/SECURITY/CODE_OF_CONDUCT, Codecov, and a semver policy it holds to.
 
 The sweet spot: a small, dependency-light helper several services share that nothing upstream covers cleanly.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ go get github.com/a-novel-kit/golib
 
 ## Sub-packages
 
+Each **sub-package** is a directory-scoped, independently importable helper — focused, dependency-light, and shared across services. One that grows a broad API of its own graduates to its own repo (see [What this is](#what-this-is)).
+
 | Path       | What it's for                                                                                                                                                                      |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `config`   | Loads environment variables into typed config structs and fails fast at startup when one is missing or malformed, so a service never boots half-configured.                        |


### PR DESCRIPTION
## Summary

- Link CONTRIBUTING to the [libraries, tooling & platform concepts](https://github.com/a-novel-kit/.github/blob/master/CONTRIBUTING.md) (the #30 deliverable) for the shared library taxonomy, instead of restating it.
- Formalize **graduation**: the bar's graduation question now points at the concepts-doc definition and names the public-package obligations that attach (own README/CONTRIBUTING/SECURITY/CODE_OF_CONDUCT, Codecov, semver), with `jwt` as the worked example.
- Define **sub-package** explicitly in the README's Sub-packages section.

Doc-only; no code change. Part of the **Taxonomy & glossary** milestone (a-novel-kit/.github#29).

Closes #311