### PR TITLE
ci: rename the Go test job to test-go

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,7 +55,7 @@ jobs:
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
 
-  test:
+  test-go:
     needs: [lint-go]
     runs-on: ubuntu-latest
     permissions:
@@ -68,7 +68,7 @@ jobs:
   report-grc:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && success()
-    needs: [test, lint-go]
+    needs: [test-go, lint-go]
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Renames the Go test job `test` → `test-go` so its required-check context is lane-suffixed (matching `lint-go` / `generated-go`), per a-novel-kit/stack#133. Bare-verb contexts collide across languages and break repocfg's check discovery. The job already calls `go-actions/test-go`; only the job id was bare.

## ⚠️ Merge note (admin)

The live `master` ruleset still requires the old `test` context, so this PR shows `test` as missing/Expected. **Merge with admin bypass**, then immediately run `a-novel repo update --full` (human-only) to repoint the ruleset at `test-go` and drop the stale `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)