### PR TITLE
ci: rename lint-node to lint-js

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: bufbuild/buf-action@v1
 
-  lint-node:
+  lint-js:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
golib is class=library; its node lint context is `lint-js` (not `lint-node`), matching the master ruleset `repo update` reconciled. Follows #317 (`test`→`test-go`). Refs a-novel-kit/.github#40

🤖 Generated with [Claude Code](https://claude.com/claude-code)