### PR TITLE
docs: refocus comments on rationale and refine project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Each **sub-package** is a directory-scoped, independently importable helper — 
 | Path       | What it's for                                                                                                                                                                      |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `config`   | Loads environment variables into typed config structs and fails fast at startup when one is missing or malformed, so a service never boots half-configured.                        |
-| `otel`     | Wires OpenTelemetry tracing and logging under a shared app identity and reports each operation's outcome on its span. Exporters ship for local development and Google Cloud.       |
+| `otel`     | Wires OpenTelemetry tracing and logging under a shared app identity and reports each operation's outcome on its span. Exporters ship for local development and hosted backends.    |
 | `httpf`    | Holds the REST boundary logic a handler leans on — mapping domain error sentinels to HTTP status codes and writing JSON — so every service answers errors the same way.            |
-| `grpcf`    | The gRPC equivalent of `httpf`: it shapes per-call context, supplies client and server credentials (local or GCP), and bundles a health/echo service for tests.                    |
+| `grpcf`    | The gRPC equivalent of `httpf`: it shapes per-call context, supplies client dial credentials (local or GCP), and bundles a health/echo service for tests.                          |
 | `logging`  | Defines the interfaces the platform logs through, so a service can swap its log backend without touching call sites. Presets cover local and Google Cloud, for both HTTP and gRPC. |
 | `postgres` | Carries the database handle on the request context and scopes work into transactions, and ships a migration runner plus harnesses that give each test an isolated database.        |
 | `smtp`     | Sends transactional mail behind one `Sender` interface, with a real SMTP sender for production and a debug sender for local runs and tests.                                        |

--- a/config/env.go
+++ b/config/env.go
@@ -1,3 +1,5 @@
+// Package config reads service configuration from environment variables, mapping raw strings to
+// native Go types through composable parser functions.
 package config
 
 import (
@@ -8,8 +10,8 @@ import (
 	"time"
 )
 
-// LoadEnv cast an environment variable to a native Go type, using the provided Parser function.
-// If parsing fails, the fallback value is returned.
+// LoadEnv parses the raw environment value into T using parser, returning fallback when the value
+// is empty or the parser reports an error.
 func LoadEnv[T any](value string, fallback T, parser func(string) (T, error)) T {
 	if value == "" {
 		return fallback
@@ -27,33 +29,31 @@ func LoadEnv[T any](value string, fallback T, parser func(string) (T, error)) T 
 // The parser accepts a sub-parser to define the type of T.
 func SliceParser[T any](parser func(string) (T, error)) func(string) ([]T, error) {
 	return func(value string) ([]T, error) {
-		// To force an empty slice if the value is empty.
+		// The literal "[]" selects an empty result, overriding any fallback.
 		if value == "[]" {
 			return nil, nil
 		}
 
-		// Split source on commas.
 		parts := strings.Split(value, ",")
 
-		// Parse each part using the provided parser.
 		parsedValues := make([]T, 0, len(parts))
 
 		for _, part := range parts {
 			trimmedPart := strings.TrimSpace(part)
 			if trimmedPart == "" {
-				continue // Skip empty parts.
+				continue
 			}
 
 			parsedValue, err := parser(trimmedPart)
 			if err != nil {
-				// If any parsing fails, deem the whole slice invalid and return the fallback.
+				// One bad element invalidates the whole slice.
 				return nil, err
 			}
 
 			parsedValues = append(parsedValues, parsedValue)
 		}
 
-		// If no parts were parsed, return the fallback.
+		// A non-empty value that resolves to no elements is treated as invalid.
 		if len(parsedValues) == 0 {
 			return nil, fmt.Errorf(`value "%s" is empty`, value)
 		}
@@ -67,6 +67,7 @@ func StringParser(value string) (string, error) {
 	return value, nil
 }
 
+// EnumParser wraps another parser and rejects any parsed value absent from the allow list.
 func EnumParser[T comparable](parser func(string) (T, error), allow ...T) func(string) (T, error) {
 	return func(value string) (T, error) {
 		raw, err := parser(value)

--- a/config/must.go
+++ b/config/must.go
@@ -1,6 +1,7 @@
 package config
 
-// Must automatically panics if the error is not nil.
+// Must returns value, or panics when err is non-nil. Use it at initialization, where a failure is
+// unrecoverable and should stop the program.
 func Must[T any](value T, err error) T {
 	if err != nil {
 		panic(err)
@@ -9,7 +10,7 @@ func Must[T any](value T, err error) T {
 	return value
 }
 
-// MustUnmarshal is a utility function that panics if the unmarshal operation fails.
+// MustUnmarshal decodes src into a T using unmarshal, panicking if decoding fails.
 func MustUnmarshal[T any](unmarshal func([]byte, any) error, src []byte) T {
 	var value T
 

--- a/grpcf/any.go
+++ b/grpcf/any.go
@@ -8,14 +8,14 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// MarshalJSONAsAny serialises an arbitrary Go value to JSON and packs the
+// MarshalJSONAsAny serializes an arbitrary Go value to JSON and packs the
 // resulting bytes into a google.protobuf.Any whose contained message type is
 // google.protobuf.BytesValue. Use it only when an RPC field is typed as Any
 // and you actually want to carry an opaque JSON payload — Any is normally
 // reserved for genuine protobuf messages, so this is a deliberate escape
 // hatch, not the default way to transit data.
 //
-// The inverse is UnmarshalJSONFromAny.
+// The inverse is [UnmarshalJSONFromAny].
 func MarshalJSONAsAny(v any) (*anypb.Any, error) {
 	data, err := json.Marshal(v)
 	if err != nil {
@@ -27,7 +27,7 @@ func MarshalJSONAsAny(v any) (*anypb.Any, error) {
 	return out, anypb.MarshalFrom(out, &wrapperspb.BytesValue{Value: data}, proto.MarshalOptions{})
 }
 
-// UnmarshalJSONFromAny is the inverse of MarshalJSONAsAny: it extracts the
+// UnmarshalJSONFromAny is the inverse of [MarshalJSONAsAny]: it extracts the
 // JSON payload from a google.protobuf.Any (assumed to wrap a
 // google.protobuf.BytesValue) and decodes it into an `any` Go value.
 func UnmarshalJSONFromAny(anyValue *anypb.Any) (any, error) {

--- a/grpcf/client.go
+++ b/grpcf/client.go
@@ -18,17 +18,31 @@ var (
 	_ CredentialsProvider = (*GcloudCredentialsProvider)(nil)
 )
 
+// CredentialsProvider supplies the gRPC dial options that carry a connection's
+// transport security and, where needed, its per-call authentication. Choose the
+// implementation that matches the target: [LocalCredentialsProvider] for a
+// plaintext local connection, [GcloudCredentialsProvider] for a TLS-secured
+// Google Cloud endpoint.
 type CredentialsProvider interface {
+	// Options returns the dial options to pass when creating the client. The
+	// context bounds any token exchange the provider performs while building them.
 	Options(ctx context.Context) ([]grpc.DialOption, error)
 }
 
+// LocalCredentialsProvider dials without transport security, for plaintext
+// connections to a service on a trusted local network.
 type LocalCredentialsProvider struct{}
 
 func (provider *LocalCredentialsProvider) Options(_ context.Context) ([]grpc.DialOption, error) {
 	return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}, nil
 }
 
+// GcloudCredentialsProvider dials a Google Cloud endpoint over TLS and attaches
+// a Google-issued OIDC identity token to every call, the scheme Cloud Run uses
+// to authenticate service-to-service traffic.
 type GcloudCredentialsProvider struct {
+	// Host is the endpoint hostname, without scheme or port. It sets both the
+	// identity token's audience and the TLS authority for the connection.
 	Host string
 }
 

--- a/grpcf/context.go
+++ b/grpcf/context.go
@@ -6,6 +6,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+// BaseContextUnaryInterceptor returns a unary server interceptor that runs
+// ctxInterceptor on each request's context before the handler sees it, giving
+// every RPC a single place to seed request-scoped values such as a logger or a
+// tracing span.
 func BaseContextUnaryInterceptor(
 	ctxInterceptor func(context.Context) context.Context,
 ) grpc.UnaryServerInterceptor {
@@ -16,6 +20,8 @@ func BaseContextUnaryInterceptor(
 	}
 }
 
+// wrappedStream overrides a ServerStream's Context so the transformed context
+// reaches the handler; gRPC exposes no other hook to replace a stream's context.
 type wrappedStream struct {
 	grpc.ServerStream
 
@@ -26,6 +32,10 @@ func (stream *wrappedStream) Context() context.Context {
 	return stream.ctxInterceptor(stream.ServerStream.Context())
 }
 
+// BaseContextStreamInterceptor is the streaming counterpart to
+// [BaseContextUnaryInterceptor]: it applies ctxInterceptor to the stream's
+// context so every ServerStream.Context call inside the handler observes the
+// transformed context.
 func BaseContextStreamInterceptor(
 	ctxInterceptor func(context.Context) context.Context,
 ) grpc.StreamServerInterceptor {

--- a/grpcf/echo.go
+++ b/grpcf/echo.go
@@ -28,8 +28,8 @@ func (handler *echo) UnaryEcho(context.Context, *golibproto.UnaryEchoRequest) (*
 // shutdown.
 //
 // A non-positive healthPing degrades to a tight toggle loop that still
-// honours ctx cancellation — `time.NewTicker` would panic on a zero or
-// negative duration, so the wait is built around `time.After` instead.
+// honors ctx cancellation. time.NewTicker would panic on a zero or negative
+// duration, so the wait is built around time.After instead.
 func SetEchoServersContext(ctx context.Context, server *grpc.Server, healthPing time.Duration) {
 	healthcheck := health.NewServer()
 	healthpb.RegisterHealthServer(server, healthcheck)

--- a/grpcf/proto/echo.proto
+++ b/grpcf/proto/echo.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+// EchoService is a minimal reference service for probing gRPC connectivity,
+// exercising each streaming mode, and backing liveness checks.
 service EchoService {
   rpc UnaryEcho(UnaryEchoRequest) returns (UnaryEchoResponse) {}
   rpc ServerStreamingEcho(ServerStreamingEchoRequest) returns (stream ServerStreamingEchoResponse) {}

--- a/grpcf/proto/gen/echo_grpc.pb.go
+++ b/grpcf/proto/gen/echo_grpc.pb.go
@@ -28,6 +28,9 @@ const (
 // EchoServiceClient is the client API for EchoService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// EchoService is a minimal reference service for probing gRPC connectivity,
+// exercising each streaming mode, and backing liveness checks.
 type EchoServiceClient interface {
 	UnaryEcho(ctx context.Context, in *UnaryEchoRequest, opts ...grpc.CallOption) (*UnaryEchoResponse, error)
 	ServerStreamingEcho(ctx context.Context, in *ServerStreamingEchoRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ServerStreamingEchoResponse], error)
@@ -101,6 +104,9 @@ type EchoService_BidirectionalStreamingEchoClient = grpc.BidiStreamingClient[Bid
 // EchoServiceServer is the server API for EchoService service.
 // All implementations must embed UnimplementedEchoServiceServer
 // for forward compatibility.
+//
+// EchoService is a minimal reference service for probing gRPC connectivity,
+// exercising each streaming mode, and backing liveness checks.
 type EchoServiceServer interface {
 	UnaryEcho(context.Context, *UnaryEchoRequest) (*UnaryEchoResponse, error)
 	ServerStreamingEcho(*ServerStreamingEchoRequest, grpc.ServerStreamingServer[ServerStreamingEchoResponse]) error

--- a/httpf/error.go
+++ b/httpf/error.go
@@ -1,3 +1,7 @@
+// Package httpf holds small helpers for writing HTTP handler responses that stay
+// consistent with the service's OpenTelemetry tracing and structured logging: every
+// outcome is recorded on the request span so handlers report success and failure the
+// same way.
 package httpf
 
 import (
@@ -11,8 +15,14 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 )
 
+// ErrMap maps sentinel errors to the HTTP status HandleError returns for them. A nil
+// key sets the fallback status for unmatched errors; without one, they fall back to
+// 500 Internal Server Error.
 type ErrMap map[error]int
 
+// HandleError writes a response for a failed handler. It records err on the span,
+// matches it against errMap (with errors.Is) to pick a status, logs it, and writes the
+// status text as the body. Unmatched errors default to 500 Internal Server Error.
 func HandleError(
 	ctx context.Context, logger logging.Log, w http.ResponseWriter, span trace.Span, errMap ErrMap, err error,
 ) {
@@ -20,7 +30,7 @@ func HandleError(
 	status := http.StatusInternalServerError
 
 	for ref, refStatus := range errMap {
-		// Default value override. Only effective if no other error matches.
+		// A nil key only sets the fallback status; keep scanning, since a concrete match wins.
 		if ref == nil {
 			status = refStatus
 

--- a/httpf/json.go
+++ b/httpf/json.go
@@ -10,6 +10,10 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 )
 
+// SendJSON encodes data as JSON to w with a JSON content type and records the outcome
+// on the span. An encoding failure is reported on the span; by then the status line is
+// already sent, so the body may be truncated. The caller sets any non-200 status before
+// calling.
 func SendJSON[Data any](_ context.Context, w http.ResponseWriter, span trace.Span, data Data) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/logging/http.go
+++ b/logging/http.go
@@ -4,8 +4,11 @@ import (
 	"net/http"
 )
 
-// HTTPConfig is implemented by anything that produces an HTTP middleware
-// chain emitting structured access logs.
+// HTTPConfig produces the middleware that logs every HTTP request. The presets
+// subpackage implements it in a local (human-readable) and a Google Cloud
+// (structured) variant.
 type HTTPConfig interface {
+	// Logger returns a middleware that wraps a handler and records one
+	// access-log entry per request, at a level chosen from the response status.
 	Logger() func(http.Handler) http.Handler
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,9 +1,19 @@
+// Package logging defines the logging contracts a service wires into its HTTP
+// and gRPC servers. It holds only interfaces; the presets subpackage supplies
+// the concrete implementations, in a human-readable local variant and a
+// structured Google Cloud variant.
 package logging
 
 import "context"
 
+// Log is a leveled, context-aware logger. The context carries the request-scoped
+// trace information an implementation attaches to each entry, and fields hold any
+// extra data to record alongside the message.
 type Log interface {
+	// Info records a routine event.
 	Info(ctx context.Context, msg string, fields ...any)
+	// Warn records a problem the request recovered from.
 	Warn(ctx context.Context, msg string, fields ...any)
+	// Err records a failure.
 	Err(ctx context.Context, msg string, fields ...any)
 }

--- a/logging/presets/grpc.gcloud.go
+++ b/logging/presets/grpc.gcloud.go
@@ -13,6 +13,9 @@ import (
 
 var _ logging.RPCConfig = (*GRPCGcloud)(nil)
 
+// GRPCGcloud implements [logging.RPCConfig] for Google Cloud, producing gRPC
+// interceptors that emit structured JSON to stderr and recover from handler
+// panics. Component labels every entry with the emitting subsystem.
 type GRPCGcloud struct {
 	Component string `json:"component" yaml:"component"`
 

--- a/logging/presets/grpc.local.go
+++ b/logging/presets/grpc.local.go
@@ -13,6 +13,9 @@ import (
 
 var _ logging.RPCConfig = (*GRPCLocal)(nil)
 
+// GRPCLocal implements [logging.RPCConfig] for local development, producing
+// gRPC interceptors that emit human-readable text to stdout and recover from
+// handler panics. Component labels every entry with the emitting subsystem.
 type GRPCLocal struct {
 	Component string `json:"component" yaml:"component"`
 

--- a/logging/presets/http.gcloud.go
+++ b/logging/presets/http.gcloud.go
@@ -18,6 +18,10 @@ import (
 
 var _ logging.HTTPConfig = (*HTTPGcloud)(nil)
 
+// HTTPGcloud implements [logging.HTTPConfig] for Google Cloud. Its middleware
+// times each request, records a trace span, and emits a structured access log
+// whose fields Cloud Logging correlates with that trace. It logs through
+// BaseLogger.
 type HTTPGcloud struct {
 	BaseLogger *LogGcloud
 }
@@ -55,16 +59,17 @@ func (logger *HTTPGcloud) Logger() func(http.Handler) http.Handler {
 				logFn = logger.BaseLogger.Info
 			}
 
-			// Extract trace info for GCP
 			spanCtx := span.SpanContext()
 			traceID := spanCtx.TraceID().String()
 			spanID := spanCtx.SpanID().String()
 			traceSampled := spanCtx.IsSampled()
 
-			// GCP trace field format
+			// Cloud Logging links a log to its trace only when the trace is
+			// given as this full project-scoped resource name.
 			traceResource := fmt.Sprintf("projects/%s/traces/%s", logger.BaseLogger.ProjectId, traceID)
 
-			// Build structured log entry
+			// The magic field names below are the contract Cloud Logging reads
+			// to correlate the entry with its trace and to unpack the request.
 			// https://docs.cloud.google.com/logging/docs/structured-logging
 			logFn(
 				r.Context(),

--- a/logging/presets/http.local.go
+++ b/logging/presets/http.local.go
@@ -14,6 +14,9 @@ import (
 
 var _ logging.HTTPConfig = (*HTTPLocal)(nil)
 
+// HTTPLocal implements [logging.HTTPConfig] for local development, printing a
+// one-line, color-coded summary of each request to the terminal. It logs
+// through BaseLogger.
 type HTTPLocal struct {
 	BaseLogger *LogLocal
 }
@@ -55,16 +58,16 @@ func (logger *HTTPLocal) Logger() func(http.Handler) http.Handler {
 
 			lstyleExtra := lipgloss.NewStyle().Faint(true)
 
-			message := lstyle.Render(fmt.Sprintf("%s %s %s", prefix, r.Method, r.URL.Path)) // Path
-			message += lstyleExtra.Render(fmt.Sprintf(" (%s)", latency))                    // Latency
-			message = lstyleExtra.Render(start.Format(time.StampNano)) + " " + message      // Start time
+			message := lstyle.Render(fmt.Sprintf("%s %s %s", prefix, r.Method, r.URL.Path))
+			message += lstyleExtra.Render(fmt.Sprintf(" (%s)", latency))
+			message = lstyleExtra.Render(start.Format(time.StampNano)) + " " + message
 
 			if body != "" {
 				message += lstyle.Render("\n\t" + strings.ReplaceAll(body, "\n", "\n\t"))
 			}
 
-			// Local development only, so mitigated security risk.
-
+			// Dumping the raw response body would leak sensitive data in
+			// production, but this preset only ever runs in local development.
 			_, _ = fmt.Fprint(logger.BaseLogger.Out, strings.TrimSpace(message)+"\n")
 		})
 	}

--- a/logging/presets/logging.gcloud.go
+++ b/logging/presets/logging.gcloud.go
@@ -6,6 +6,10 @@ import (
 	"os"
 )
 
+// LogGcloud implements the logging.Log interface for Google Cloud, writing
+// entries as structured JSON to stderr with a severity field that Cloud Logging
+// understands. ProjectId names the Google Cloud project, and scopes the trace
+// resource names the HTTP preset attaches to access logs.
 type LogGcloud struct {
 	ProjectId string `json:"projectID" yaml:"projectID"`
 	l         *slog.Logger

--- a/logging/presets/logging.local.go
+++ b/logging/presets/logging.local.go
@@ -8,6 +8,9 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
+// LogLocal implements the logging.Log interface for local development,
+// rendering each entry in a severity color to Out. It carries no trace
+// context, since the output is meant to be read directly in a terminal.
 type LogLocal struct {
 	Out io.Writer
 }

--- a/logging/presets/utils.go
+++ b/logging/presets/utils.go
@@ -1,17 +1,30 @@
+// Package loggingpresets provides ready-made implementations of the logging
+// package interfaces for the two environments a service runs in: Google Cloud
+// and local development. The Gcloud presets emit structured JSON that Cloud
+// Logging parses and correlates with traces; the Local presets emit
+// human-readable, color-coded output for a developer's terminal. Each
+// environment offers a base logger plus HTTP and gRPC middleware built on it.
 package loggingpresets
 
 import "charm.land/lipgloss/v2"
 
+// Terminal colors the Local presets use to distinguish log severities.
 var (
 	LipColorError = lipgloss.Color("#ff3232")
 	LipColorWarn  = lipgloss.Color("#ffb600")
 	LipColorInfo  = lipgloss.Color("#25e6e3")
 )
 
+// LogLevel is the severity of a log entry. Each preset maps it to that
+// environment's native representation — a Google Cloud severity string, or a
+// terminal color.
 type LogLevel int
 
 const (
+	// LogLevelInfo marks a normal, expected event.
 	LogLevelInfo LogLevel = iota
+	// LogLevelWarn marks a recoverable problem worth attention.
 	LogLevelWarn
+	// LogLevelError marks a failure.
 	LogLevelError
 )

--- a/logging/rpc.go
+++ b/logging/rpc.go
@@ -2,12 +2,18 @@ package logging
 
 import "google.golang.org/grpc"
 
-// RPCConfig is implemented by anything that produces gRPC interceptors —
-// both for emitting structured access logs (Unary/Stream Interceptor) and
-// for recovering from handler panics (PanicUnary/PanicStream Interceptor).
+// RPCConfig produces the gRPC server interceptors a service installs: access
+// logging for unary and streaming calls, plus panic recovery that turns a
+// handler panic into an internal error. The presets subpackage implements it in
+// a local and a Google Cloud variant.
 type RPCConfig interface {
+	// UnaryInterceptor logs each unary call.
 	UnaryInterceptor() grpc.UnaryServerInterceptor
+	// StreamInterceptor logs each streaming call.
 	StreamInterceptor() grpc.StreamServerInterceptor
+	// PanicUnaryInterceptor recovers from a panic in a unary handler, logging it
+	// and returning an internal error to the caller.
 	PanicUnaryInterceptor() grpc.UnaryServerInterceptor
+	// PanicStreamInterceptor recovers from a panic in a streaming handler.
 	PanicStreamInterceptor() grpc.StreamServerInterceptor
 }

--- a/otel/config.go
+++ b/otel/config.go
@@ -13,18 +13,32 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// A Config wires one OpenTelemetry backend into the process. Each implementation
+// targets a single destination for traces and logs; the presets subpackage ships
+// the ready-made ones (standard output, Google Cloud, Sentry, and a disabled
+// no-op). Pass a Config to Init to install its providers as the global state.
 type Config interface {
+	// Init sets up the backend's SDK clients and prints its startup banner.
 	Init() error
+	// GetPropagators returns the propagator that extracts and injects trace
+	// context across service boundaries.
 	GetPropagators() (propagation.TextMapPropagator, error)
+	// GetTraceProvider returns the tracer provider to install globally.
 	GetTraceProvider() (trace.TracerProvider, error)
+	// GetLogger returns the logger provider to install globally.
 	GetLogger() (log.LoggerProvider, error)
+	// Flush drains buffered spans and logs; run it before the process exits.
 	Flush()
+	// HttpHandler returns middleware that instruments incoming HTTP requests.
 	HttpHandler() func(http.Handler) http.Handler
+	// RpcInterceptor returns the server option that instruments incoming gRPC calls.
 	RpcInterceptor() grpc.ServerOption
 }
 
+// Init runs the backend's own setup, then installs its propagator, tracer, and
+// logger providers as the process-global OpenTelemetry state. A nil config leaves
+// telemetry disabled and is a no-op.
 func Init(config Config) error {
-	// Telemetry disabled.
 	if config == nil {
 		return nil
 	}

--- a/otel/config.go
+++ b/otel/config.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// A Config wires one OpenTelemetry backend into the process. Each implementation
+// Config wires one OpenTelemetry backend into the process. Each implementation
 // targets a single destination for traces and logs; the presets subpackage ships
 // the ready-made ones (standard output, Google Cloud, Sentry, and a disabled
 // no-op). Pass a Config to Init to install its providers as the global state.

--- a/otel/presets/disabled.go
+++ b/otel/presets/disabled.go
@@ -21,7 +21,8 @@ import (
 
 var _ otel.Config = (*Disabled)(nil)
 
-// Disabled configures Otel to disable traces & logs.
+// Disabled is a Config whose providers are no-ops, so no traces or logs are
+// exported.
 type Disabled struct{}
 
 // Init prints a startup banner announcing that OpenTelemetry tracing and

--- a/otel/presets/gcloud.go
+++ b/otel/presets/gcloud.go
@@ -27,8 +27,14 @@ import (
 
 var _ otel.Config = (*Gcloud)(nil)
 
+// Gcloud is a Config that exports traces to Google Cloud Trace and writes
+// structured logs to stderr for Cloud Logging to collect.
 type Gcloud struct {
-	ProjectID    string        `json:"projectID"    yaml:"projectID"`
+	// ProjectID is the Google Cloud project traces are sent to. When empty, the
+	// exporter detects it from the ambient credentials.
+	ProjectID string `json:"projectID" yaml:"projectID"`
+	// FlushTimeout bounds how long Flush waits for buffered data to drain; zero
+	// waits indefinitely.
 	FlushTimeout time.Duration `json:"flushTimeout" yaml:"flushTimeout"`
 
 	tp *sdktrace.TracerProvider
@@ -46,8 +52,9 @@ func (config *Gcloud) Init() error {
 
 func (config *Gcloud) GetPropagators() (propagation.TextMapPropagator, error) {
 	return propagation.NewCompositeTextMapPropagator(
-		// Putting the CloudTraceOneWayPropagator first means the TraceContext propagator
-		// takes precedence if both the traceparent and the XCTC headers exist.
+		// On extraction the later propagator wins, so listing CloudTrace first lets a
+		// standard traceparent header take precedence over the X-Cloud-Trace-Context
+		// header when a request carries both.
 		gcppropagator.CloudTraceOneWayPropagator{},
 		propagation.TraceContext{},
 		propagation.Baggage{},
@@ -73,7 +80,8 @@ func (config *Gcloud) GetTraceProvider() (trace.TracerProvider, error) {
 	return config.tp, nil
 }
 
-// GetLogger sets up a structured JSON logger that GCP can parse and link to traces.
+// GetLogger returns a logger provider that writes structured JSON to stderr, which
+// Cloud Logging collects and correlates with traces.
 func (config *Gcloud) GetLogger() (log.LoggerProvider, error) {
 	logExporter, err := stdoutlog.New(
 		stdoutlog.WithWriter(os.Stderr),
@@ -115,7 +123,6 @@ func (config *Gcloud) Flush() {
 	}
 }
 
-// HttpHandler is kept for interface compatibility but doesn't wrap anything in GCP mode.
 func (config *Gcloud) HttpHandler() func(http.Handler) http.Handler {
 	return otelhttp.NewMiddleware("")
 }

--- a/otel/presets/local.go
+++ b/otel/presets/local.go
@@ -26,15 +26,18 @@ import (
 
 var _ otel.Config = (*Local)(nil)
 
-// Local configures OTEL to log traces & logs to stdout.
+// Local is a Config that writes traces and logs to standard output, for local
+// development.
 type Local struct {
+	// FlushTimeout bounds how long Flush waits for buffered data to drain; zero
+	// waits indefinitely.
 	FlushTimeout time.Duration `json:"flushTimeout" yaml:"flushTimeout"`
 
 	tp *sdktrace.TracerProvider
 	lp *sdklog.LoggerProvider
 }
 
-// Init just prints a banner for local dev mode.
+// Init prints the local development banner.
 func (config *Local) Init() error {
 	banner := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
 	_, _ = fmt.Fprintln(os.Stdout, banner.Render("🚀 OpenTelemetry Local Mode: All traces and logs to stdout"))

--- a/otel/presets/sentry.go
+++ b/otel/presets/sentry.go
@@ -25,11 +25,17 @@ import (
 
 var _ otel.Config = (*Sentry)(nil)
 
+// Sentry is a Config that reports traces to Sentry over OTLP and forwards captured
+// errors through the Sentry SDK.
 type Sentry struct {
-	DSN          string        `json:"dsn"          yaml:"dsn"`
-	ServerName   string        `json:"serverName"   yaml:"serverName"`
-	Release      string        `json:"release"      yaml:"release"`
-	Environment  string        `json:"environment"  yaml:"environment"`
+	// DSN is the Sentry project's ingest URL, which selects the project events are
+	// sent to.
+	DSN         string `json:"dsn"         yaml:"dsn"`
+	ServerName  string `json:"serverName"  yaml:"serverName"`
+	Release     string `json:"release"     yaml:"release"`
+	Environment string `json:"environment" yaml:"environment"`
+	// FlushTimeout bounds how long Flush waits for buffered data to drain; zero
+	// waits indefinitely.
 	FlushTimeout time.Duration `json:"flushTimeout" yaml:"flushTimeout"`
 	Debug        bool          `json:"debug"        yaml:"debug"`
 

--- a/otel/utils.go
+++ b/otel/utils.go
@@ -9,20 +9,28 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// AppName is the instrumentation scope name stamped on every tracer and logger
+// created through this package. Set it once at startup with SetAppName.
 var AppName string
 
+// SetAppName sets the instrumentation scope name used by Tracer and Logger.
 func SetAppName(name string) {
 	AppName = name
 }
 
+// Tracer returns a tracer scoped to AppName from the global tracer provider.
 func Tracer(options ...trace.TracerOption) trace.Tracer {
 	return otel.GetTracerProvider().Tracer(AppName, options...)
 }
 
+// Logger returns an slog logger scoped to AppName that writes through the global
+// OpenTelemetry logger provider.
 func Logger(options ...otelslog.Option) *slog.Logger {
 	return otelslog.NewLogger(AppName, options...)
 }
 
+// ReportError records err on the span and marks the span failed, then returns err
+// unchanged so a handler can write `return otel.ReportError(span, err)`.
 func ReportError(span trace.Span, err error) error {
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
@@ -30,12 +38,15 @@ func ReportError(span trace.Span, err error) error {
 	return err
 }
 
+// ReportSuccess marks the span successful and returns resp unchanged, for use in a
+// span's final return statement.
 func ReportSuccess[Resp any](span trace.Span, resp Resp) Resp {
 	span.SetStatus(codes.Ok, "")
 
 	return resp
 }
 
+// ReportSuccessNoContent marks the span successful when there is no value to return.
 func ReportSuccessNoContent(span trace.Span) {
 	span.SetStatus(codes.Ok, "")
 }

--- a/otel/utils/http.go
+++ b/otel/utils/http.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 )
 
+// A CaptureHTTPResponseWriter wraps an http.ResponseWriter and records the status
+// code, byte count, and full body as the handler writes them, so middleware can
+// inspect the response after the handler returns.
 type CaptureHTTPResponseWriter struct {
 	http.ResponseWriter
 
@@ -29,6 +32,8 @@ func (w *CaptureHTTPResponseWriter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
+// Status returns the captured status code, defaulting to 200 when the handler
+// wrote the body without an explicit WriteHeader call.
 func (w *CaptureHTTPResponseWriter) Status() int {
 	if w.status == 0 {
 		return http.StatusOK

--- a/otel/utils/http.go
+++ b/otel/utils/http.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-// A CaptureHTTPResponseWriter wraps an http.ResponseWriter and records the status
+// CaptureHTTPResponseWriter wraps an http.ResponseWriter and records the status
 // code, byte count, and full body as the handler writes them, so middleware can
 // inspect the response after the handler returns.
 type CaptureHTTPResponseWriter struct {

--- a/postgres/config.go
+++ b/postgres/config.go
@@ -6,7 +6,16 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// Config supplies pooled bun database connections to the rest of the package.
+// A Config owns the driver options and the connection lifecycle; the context,
+// migration, and test helpers all obtain their handles through it.
+// postgrespresets.Default is the standard implementation.
 type Config interface {
+	// DB returns a connection to the primary database, opening it on first call
+	// and reusing it thereafter.
 	DB(ctx context.Context) (*bun.DB, error)
+	// DBSchema returns a connection scoped to the named schema, creating the
+	// schema first when create is true. An empty schema name yields the primary
+	// connection.
 	DBSchema(ctx context.Context, schema string, create bool) (*bun.DB, error)
 }

--- a/postgres/context.go
+++ b/postgres/context.go
@@ -9,16 +9,22 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// ContextKey is the context value key under which the package stores the active
+// bun.IDB connection.
 type ContextKey struct{}
 
+// NameLen caps the length of a generated schema or database name, keeping it
+// within PostgreSQL's 63-byte identifier limit with room for prefixes.
 const NameLen = 31
 
-// ErrNoIDBInContext is returned by GetContext when the supplied context does
-// not carry a bun.IDB value (it was never seeded via NewContext / one of its
-// variants). It is sibling to ErrNoDbInContext in migrator.go, which signals
-// the stricter "found an IDB but it isn't a *bun.DB" case.
+// ErrNoIDBInContext is returned by GetContext when the context carries no
+// bun.IDB, meaning it was never seeded by NewContext or one of its variants.
+// [ErrNoDbInContext] covers the stricter case where a connection is present but
+// is not a full *bun.DB.
 var ErrNoIDBInContext = errors.New("context does not contain a bun.IDB")
 
+// NewContext derives a context carrying a connection to the primary database,
+// for later retrieval with GetContext.
 func NewContext(ctx context.Context, config Config) (context.Context, error) {
 	db, err := config.DB(ctx)
 	if err != nil {
@@ -28,6 +34,8 @@ func NewContext(ctx context.Context, config Config) (context.Context, error) {
 	return context.WithValue(ctx, ContextKey{}, db), nil
 }
 
+// NewContextSchema derives a context carrying a connection scoped to the named
+// schema, creating the schema first when create is true.
 func NewContextSchema(ctx context.Context, config Config, schema string, create bool) (context.Context, error) {
 	db, err := config.DBSchema(ctx, schema, create)
 	if err != nil {
@@ -37,6 +45,8 @@ func NewContextSchema(ctx context.Context, config Config, schema string, create 
 	return context.WithValue(ctx, ContextKey{}, db), nil
 }
 
+// GetContext returns the bun.IDB stored in ctx by NewContext or one of its
+// variants, or ErrNoIDBInContext when none is present.
 func GetContext(ctx context.Context) (bun.IDB, error) {
 	db, ok := ctx.Value(ContextKey{}).(bun.IDB)
 	if !ok {
@@ -46,6 +56,8 @@ func GetContext(ctx context.Context) (bun.IDB, error) {
 	return db, nil
 }
 
+// RunInTx runs callback within a transaction opened on the connection carried
+// by ctx. The callback receives the transaction as a bun.IDB.
 func RunInTx(ctx context.Context, opts *sql.TxOptions, callback func(ctx context.Context, tx bun.IDB) error) error {
 	db, err := GetContext(ctx)
 	if err != nil {

--- a/postgres/migrator.go
+++ b/postgres/migrator.go
@@ -12,6 +12,9 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 )
 
+// ErrNoDbInContext is returned by RunMigrationsContext when the context carries
+// a bun.IDB that is not a full *bun.DB. Migrations need a database handle, not a
+// transaction; [ErrNoIDBInContext] covers the case of no connection at all.
 var ErrNoDbInContext = errors.New("context does not contain a bun.DB")
 
 // RunMigrations runs all the migrations found in the provided filesystem.

--- a/postgres/passthrough.go
+++ b/postgres/passthrough.go
@@ -21,6 +21,8 @@ type PassthroughTx struct {
 	bun.Tx
 }
 
+// NewPassthroughTx wraps tx so that nested transaction calls resolve to tx
+// itself rather than opening savepoints.
 func NewPassthroughTx(tx bun.Tx) *PassthroughTx {
 	return &PassthroughTx{Tx: tx}
 }
@@ -36,12 +38,12 @@ func (tx *PassthroughTx) Rollback() error {
 }
 
 func (tx *PassthroughTx) Begin() (bun.Tx, error) {
-	// no-op, return the same transaction.
+	// no-op.
 	return tx.Tx, nil
 }
 
 func (tx *PassthroughTx) BeginTx(_ context.Context, _ *sql.TxOptions) (bun.Tx, error) {
-	// no-op, return the same transaction.
+	// no-op.
 	return tx.Tx, nil
 }
 

--- a/postgres/ping.go
+++ b/postgres/ping.go
@@ -17,7 +17,7 @@ const (
 )
 
 // Ping a database connection until it succeeds or the timeout is reached.
-// Honours ctx cancellation both for the PingContext call and for the wait
+// Honors ctx cancellation both for the PingContext call and for the wait
 // between retries.
 func Ping(ctx context.Context, client *bun.DB) error {
 	start := time.Now()

--- a/postgres/presets/default.go
+++ b/postgres/presets/default.go
@@ -14,24 +14,27 @@ import (
 )
 
 const (
-	// CreateSchema is the SQL statement used to create a schema in PostgreSQL.
-	//
-	// We use fmt rather than query arguments because sanitization
-	// does not expect schema names to be passed as arguments.
+	// CreateSchema is the format string for the statement that creates a schema.
+	// Schema names cannot be passed as query parameters, so the name is
+	// interpolated into the statement rather than bound.
 	CreateSchema = "CREATE SCHEMA IF NOT EXISTS %s;"
 )
 
+// Default is the standard postgres.Config implementation, backed by pgdriver.
+// It opens connections lazily and caches them: one for the primary database and
+// one per requested schema, all guarded by a single mutex.
 type Default struct {
 	options []pgdriver.Option
 
-	// Main database connection.
+	// Cached connection to the primary database, opened on first use.
 	db *bun.DB
-	// Maintain separate connections for each schema.
+	// Cached connection per schema name.
 	schemas map[string]*bun.DB
 
 	mu sync.RWMutex
 }
 
+// NewDefault returns a Default that connects using the given pgdriver options.
 func NewDefault(options ...pgdriver.Option) *Default {
 	return &Default{
 		options: options,
@@ -104,6 +107,9 @@ func (config *Default) DBSchema(ctx context.Context, schema string, create bool)
 	return db, nil
 }
 
+// Options returns a copy of the driver options the config was built with.
+// postgres.RunDBTest reads them to derive sibling connections to other
+// databases in the same cluster.
 func (config *Default) Options() []pgdriver.Option {
 	config.mu.RLock()
 	defer config.mu.RUnlock()

--- a/postgres/test.go
+++ b/postgres/test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/uptrace/bun/driver/pgdriver"
 )
 
-// A TransactionalTestFunc is the body of a database-backed test, run with a
+// TransactionalTestFunc is the body of a database-backed test, run with a
 // context carrying the connection isolated for that test.
 type TransactionalTestFunc func(context.Context, *testing.T)
 

--- a/postgres/test.go
+++ b/postgres/test.go
@@ -21,8 +21,12 @@ import (
 	"github.com/uptrace/bun/driver/pgdriver"
 )
 
+// A TransactionalTestFunc is the body of a database-backed test, run with a
+// context carrying the connection isolated for that test.
 type TransactionalTestFunc func(context.Context, *testing.T)
 
+// NewContextTest derives a context bound to a fresh, randomly named schema
+// created through config, isolating the test from others sharing the database.
 func NewContextTest(ctx context.Context, config Config) (context.Context, error) {
 	schemaName := "ta_" + strings.ToLower(rand.Text())
 	schemaName = fmt.Sprintf("%.*s", NameLen, schemaName)
@@ -136,8 +140,8 @@ var (
 	dbTestMu        sync.Mutex
 	dbTestTemplated = map[string]bool{}
 
-	// dbTestCloneMu serialises CREATE DATABASE … TEMPLATE within a process.
-	// PostgreSQL serialises CREATE DATABASE globally on the server anyway, so
+	// dbTestCloneMu serializes CREATE DATABASE … TEMPLATE within a process.
+	// PostgreSQL serializes CREATE DATABASE globally on the server anyway, so
 	// firing N parallel clones only produces N contending statements and a
 	// retry storm; taking them one at a time client-side matches what the
 	// server does regardless and removes the contention entirely. The bounded
@@ -215,7 +219,7 @@ func RunDBTest(t *testing.T, config Config, migrations fs.FS, callback Transacti
 }
 
 // dbTestEnsureTemplate returns the name of a migrated template database for the
-// given migration set, creating and migrating it on first use. It serialises
+// given migration set, creating and migrating it on first use. It serializes
 // in-process callers on dbTestMu so the migrations run exactly once per
 // process; cross-process duplication is prevented inside dbTestCreateTemplate.
 func dbTestEnsureTemplate(ctx context.Context, options []pgdriver.Option, migrations fs.FS) (string, error) {
@@ -363,7 +367,7 @@ func dbTestCreateInstance(ctx context.Context, maintenance *bun.DB, instance, te
 		dbTestQuoteIdent(instance), dbTestQuoteIdent(template),
 	)
 
-	// Serialise clones in-process: PostgreSQL serialises CREATE DATABASE
+	// Serialize clones in-process: PostgreSQL serializes CREATE DATABASE
 	// globally anyway, so taking them one at a time here matches the server
 	// and leaves the retry below to handle only cross-process contention.
 	dbTestCloneMu.Lock()
@@ -469,7 +473,7 @@ func dbTestTemplateName(migrations fs.FS) (string, error) {
 }
 
 // dbTestAdvisoryKey maps a database name to the int64 key used with
-// pg_advisory_lock, so concurrent test binaries serialise template creation on
+// pg_advisory_lock, so concurrent test binaries serialize template creation on
 // the same value.
 func dbTestAdvisoryKey(name string) int64 {
 	sum := sha256.Sum256([]byte(name))

--- a/smtp/sender.debug.go
+++ b/smtp/sender.debug.go
@@ -7,10 +7,15 @@ import (
 	"text/template"
 )
 
+// DebugSender is a Sender that renders the mail template to an io.Writer
+// instead of delivering it, for local development where no SMTP server is
+// available. Recipients are ignored and Ping always succeeds.
 type DebugSender struct {
 	writer io.Writer
 }
 
+// NewDebugSender returns a DebugSender writing to writer, defaulting to
+// os.Stdout when writer is nil.
 func NewDebugSender(writer io.Writer) *DebugSender {
 	if writer == nil {
 		writer = os.Stdout

--- a/smtp/sender.go
+++ b/smtp/sender.go
@@ -1,3 +1,7 @@
+// Package smtp sends templated transactional email through a pluggable Sender.
+// A Sender renders a text/template into the message body and delivers it; the
+// package ships a production sender backed by net/smtp and a debug sender that
+// writes the rendered body to a writer instead of dialing a server.
 package smtp
 
 import (
@@ -8,30 +12,45 @@ import (
 	"github.com/samber/lo"
 )
 
+// A MailUser is a single mail participant, pairing a display name with its
+// email address.
 type MailUser struct {
 	Name  string
 	Email string
 }
 
+// String renders the participant as an RFC 5322 address, "Name <email>".
 func (mailUser MailUser) String() string {
 	return fmt.Sprintf("%s <%s>", mailUser.Name, mailUser.Email)
 }
 
+// MailUsers is a list of recipients.
 type MailUsers []MailUser
 
+// String renders every recipient as a comma-separated address list, suitable
+// for a message header.
 func (mailUsers MailUsers) String() string {
 	return strings.Join(lo.Map(mailUsers, func(item MailUser, _ int) string {
 		return item.String()
 	}), ", ")
 }
 
+// Emails returns just the email addresses, dropping the display names.
 func (mailUsers MailUsers) Emails() []string {
 	return lo.Map(mailUsers, func(item MailUser, _ int) string {
 		return item.Email
 	})
 }
 
+// Sender delivers a rendered mail template to a set of recipients. Callers
+// depend on this interface rather than a concrete type so the delivery backend
+// can be swapped per environment: a real SMTP server in production, a writer in
+// local development, an in-memory recorder in tests.
 type Sender interface {
+	// SendMail renders template tName from t with data and delivers the result
+	// to the given recipients.
 	SendMail(to MailUsers, t *template.Template, tName string, data any) error
+	// Ping reports whether the sender can reach its backend, for use as a
+	// readiness check.
 	Ping() error
 }

--- a/smtp/sender.go
+++ b/smtp/sender.go
@@ -12,7 +12,7 @@ import (
 	"github.com/samber/lo"
 )
 
-// A MailUser is a single mail participant, pairing a display name with its
+// MailUser is a single mail participant, pairing a display name with its
 // email address.
 type MailUser struct {
 	Name  string

--- a/smtp/sender.prod.go
+++ b/smtp/sender.prod.go
@@ -7,6 +7,9 @@ import (
 	"text/template"
 )
 
+// ProdSender delivers mail through a real SMTP server using net/smtp. Its
+// fields are populated from configuration; the password is never serialized
+// back out.
 type ProdSender struct {
 	Addr   string `json:"addr"   yaml:"addr"`
 	Name   string `json:"name"   yaml:"name"`
@@ -15,7 +18,9 @@ type ProdSender struct {
 
 	Password string `json:"-" yaml:"-"`
 
-	// Dangerous setting, only use it for local development.
+	// ForceUnencryptedTls allows plaintext authentication over a connection the
+	// server has not secured with TLS, sending credentials in the clear. Use it
+	// only against a local test SMTP server; never enable it in production.
 	ForceUnencryptedTls bool `json:"forceUnencryptedTLS" yaml:"forceUnencryptedTLS"`
 }
 
@@ -72,6 +77,9 @@ func (sender *ProdSender) Ping() error {
 	return nil
 }
 
+// unencryptedAuth wraps an smtp.Auth to report the connection as TLS-secured,
+// bypassing net/smtp's refusal to send plaintext credentials over an
+// unencrypted link. Reached only through ProdSender.ForceUnencryptedTls.
 type unencryptedAuth struct {
 	smtp.Auth
 }

--- a/smtp/smtptest/sender.go
+++ b/smtp/smtptest/sender.go
@@ -1,16 +1,7 @@
-// Package smtptest provides an in-memory implementation of smtp.Sender for use
-// in unit and integration tests. Its types satisfy the smtp.Sender interface,
-// so a test can substitute *smtptest.Sender wherever an smtp.Sender is
-// expected.
-//
-// Historically these helpers lived in the parent `smtp` package as
-// `smtp.TestSender` / `smtp.TestMail` / `smtp.NewTestSender` /
-// `smtp.ErrPingTestSender`, defined in a file named `smtp/sender.test.go`. The
-// dot-suffixed filename looked like a test-only signal but was not — Go's
-// build tooling only excludes files ending in `_test.go` (underscore) from
-// production builds, so the legacy symbols shipped in every consumer binary
-// regardless of whether they were used. The dedicated sub-package makes the
-// boundary explicit; the legacy symbols were removed in the v1.0 cleanup.
+// Package smtptest provides an in-memory smtp.Sender for unit and integration
+// tests. Its Sender records every SendMail call instead of reaching a network,
+// so a test can substitute *smtptest.Sender wherever an smtp.Sender is expected
+// and later assert on what was sent.
 package smtptest
 
 import (
@@ -65,14 +56,13 @@ func (sender *Sender) Ping() error {
 }
 
 // FindMail returns the first captured Mail for which cmp returns true, or
-// (nil, false) if no captured Mail matched.
+// (nil, false) if none matched.
 //
-// The lock is released before cmp is invoked: snapshotting the pointer slice
-// under the lock and iterating afterwards prevents a deadlock if cmp
-// re-enters the Sender (e.g. by calling SendMail or FindMail again), and
-// avoids unnecessarily blocking concurrent SendMail callers for the duration
-// of a slow comparator. The returned *Mail aliases the captured entry —
-// callers must not mutate it.
+// cmp runs after the lock is released, against a snapshot of the captured
+// pointers: this keeps a slow comparator from blocking concurrent SendMail
+// callers, and a re-entrant one (that calls back into SendMail) from
+// deadlocking. The returned *Mail aliases the captured entry — callers must
+// not mutate it.
 func (sender *Sender) FindMail(cmp func(*Mail) bool) (*Mail, bool) {
 	sender.mu.RLock()
 	snapshot := append([]*Mail(nil), sender.mails...)


### PR DESCRIPTION
## Summary

Sweeps in-code comments and the project docs (README/CONTRIBUTING) against the sharpened documentation contract: **rationale over restatement**, plain voice, comments paced as navigation. Removes copy-pasted spec text in favor of concise prose plus the authoritative link, adds missing docs on exported symbols, and corrects claims that had drifted from the code.

## Scope

Comments and documentation only — **no code changed** (verified: code tokens are identical after ignoring comments and whitespace across every `.go`/`.ts`/`.proto` file). Proto Go was regenerated so the generated doc comments match the edited `.proto` files.
Excluded: `.github/**` (managed by `a-novel repo update`), `builds/**` (deployment infra), generated/test files, `CODE_OF_CONDUCT`/`LICENSE`.

## Test plan

- [x] Repo formatter is a no-op after the sweep
- [x] Comment-only gate passes
- [ ] CI green