### PR TITLE
feat(postgres): install the transaction on the context, and deprecate RunInTx

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,6 +60,28 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # The postgres package wraps a real database, so its tests need one. Without
+    # this the package cannot be tested at all, which is how a transaction
+    # helper that never opened a transaction survived here.
+    env:
+      POSTGRES_DSN: "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
+    services:
+      postgres:
+        image: postgres:18.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        # The job starts as soon as the container is up, which is earlier than
+        # the server accepts connections. Without the health gate the first test
+        # races the database and fails as a flake nobody can reproduce.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: a-novel-kit/workflows/go-actions/test-go@v1.20.0
         with:

--- a/README.md
+++ b/README.md
@@ -30,15 +30,16 @@ go get github.com/a-novel-kit/golib
 
 Each **sub-package** is a directory-scoped, independently importable helper — focused, dependency-light, and shared across services. One that grows a broad API of its own graduates to its own repo (see [What this is](#what-this-is)).
 
-| Path       | What it's for                                                                                                                                                                      |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `config`   | Loads environment variables into typed config structs and fails fast at startup when one is missing or malformed, so a service never boots half-configured.                        |
-| `otel`     | Wires OpenTelemetry tracing and logging under a shared app identity and reports each operation's outcome on its span. Exporters ship for local development and hosted backends.    |
-| `httpf`    | Holds the REST boundary logic a handler leans on — mapping domain error sentinels to HTTP status codes and writing JSON — so every service answers errors the same way.            |
-| `grpcf`    | The gRPC equivalent of `httpf`: it shapes per-call context, supplies client dial credentials (local or GCP), and bundles a health/echo service for tests.                          |
-| `logging`  | Defines the interfaces the platform logs through, so a service can swap its log backend without touching call sites. Presets cover local and Google Cloud, for both HTTP and gRPC. |
-| `postgres` | Carries the database handle on the request context and scopes work into transactions, and ships a migration runner plus harnesses that give each test an isolated database.        |
-| `smtp`     | Sends transactional mail behind one `Sender` interface, with a real SMTP sender for production and a debug sender for local runs and tests.                                        |
+| Path          | What it's for                                                                                                                                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config`      | Loads environment variables into typed config structs and fails fast at startup when one is missing or malformed, so a service never boots half-configured.                                 |
+| `otel`        | Wires OpenTelemetry tracing and logging under a shared app identity and reports each operation's outcome on its span. Exporters ship for local development and hosted backends.             |
+| `httpf`       | Holds the REST boundary logic a handler leans on — mapping domain error sentinels to HTTP status codes and writing JSON — so every service answers errors the same way.                     |
+| `grpcf`       | The gRPC equivalent of `httpf`: it shapes per-call context, supplies client dial credentials (local or GCP), and bundles a health/echo service for tests.                                   |
+| `logging`     | Defines the interfaces the platform logs through, so a service can swap its log backend without touching call sites. Presets cover local and Google Cloud, for both HTTP and gRPC.          |
+| `postgres`    | Carries the database handle on the request context and runs work inside transactions installed on it, and ships a migration runner plus harnesses that give each test an isolated database. |
+| `smtp`        | Sends transactional mail behind one `Sender` interface, with a real SMTP sender for production and a debug sender for local runs and tests.                                                 |
+| `transaction` | Declares what a unit of work is, in one interface that names no database — so business code can require atomicity without gaining a way to reach a driver. `postgres` implements it.        |
 
 ## Contributing
 

--- a/postgres/context.go
+++ b/postgres/context.go
@@ -58,6 +58,17 @@ func GetContext(ctx context.Context) (bun.IDB, error) {
 
 // RunInTx runs callback within a transaction opened on the connection carried
 // by ctx. The callback receives the transaction as a bun.IDB.
+//
+// The context it hands the callback is the original one, still carrying the
+// pool — so anything inside that resolves its handle with [GetContext] gets the
+// pool back and commits independently of the surrounding transaction, silently.
+// Only calls made through the tx argument take part, and a caller who threads
+// ctx instead has a block that opens a transaction, commits it, and protects
+// nothing. Nothing about that fails or logs.
+//
+// Deprecated: use [WithinTx], whose callback takes no transaction argument
+// because the transaction is installed on the context it receives. With nothing
+// to thread, the mistake above cannot be written.
 func RunInTx(ctx context.Context, opts *sql.TxOptions, callback func(ctx context.Context, tx bun.IDB) error) error {
 	db, err := GetContext(ctx)
 	if err != nil {

--- a/postgres/testdata/migrations/20260722000000_transaction_probe.down.sql
+++ b/postgres/testdata/migrations/20260722000000_transaction_probe.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE transaction_probe;

--- a/postgres/testdata/migrations/20260722000000_transaction_probe.up.sql
+++ b/postgres/testdata/migrations/20260722000000_transaction_probe.up.sql
@@ -1,0 +1,6 @@
+-- A table the transaction tests write to. It exists only so a rollback has
+-- something observable to discard: the assertion is whether the row is there,
+-- so the columns are the minimum that makes a row identifiable.
+CREATE TABLE transaction_probe (
+  id text PRIMARY KEY NOT NULL CHECK (id <> '')
+);

--- a/postgres/transaction.go
+++ b/postgres/transaction.go
@@ -1,0 +1,93 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+// WithTx derives a context carrying tx, so GetContext resolves the transaction
+// rather than the pool it was opened on.
+//
+// [WithinTx] applies this for you and is what callers normally want. WithTx is
+// exported for the cases that own the transaction lifecycle themselves — a test
+// harness wrapping a whole suite, or a caller bridging a transaction it opened
+// through some other API.
+func WithTx(ctx context.Context, tx bun.IDB) context.Context {
+	return context.WithValue(ctx, ContextKey{}, tx)
+}
+
+// InTx reports whether ctx carries an open transaction rather than the
+// connection pool. It reports false when ctx carries no database at all, since
+// no handle is not an open transaction.
+//
+// Work that must not hold a pooled connection — any call to an external service
+// — guards itself with this rather than trusting the convention to hold.
+//
+// It reports true under [RunTransactionalTest], whose PassthroughTx is not a
+// *bun.DB. A test covering an outbound call must therefore use [RunDBTest],
+// which puts a real pool on the context.
+func InTx(ctx context.Context) bool {
+	db, err := GetContext(ctx)
+	if err != nil {
+		return false
+	}
+
+	_, isPool := db.(*bun.DB)
+
+	return !isPool
+}
+
+// WithinTx runs callback inside a transaction opened on the connection carried
+// by ctx, and installs that transaction on the context callback receives — so
+// every call made with it takes part rather than committing on its own.
+//
+// The callback takes no transaction argument, which is the whole point: a
+// handle callers must thread through every nested call is a handle they can
+// forget, and forgetting it fails silently. With nothing to thread, the only
+// database handle reachable inside the callback is the transactional one.
+//
+// A nested call joins the transaction already in progress instead of opening a
+// savepoint, so one unit of work has one outcome and a rollback anywhere
+// discards all of it. A nested call therefore never reaches opts: an operation
+// depending on a specific isolation level must be the outermost transaction.
+func WithinTx(ctx context.Context, opts *sql.TxOptions, callback func(ctx context.Context) error) error {
+	db, err := GetContext(ctx)
+	if err != nil {
+		return fmt.Errorf("get database handle from context: %w", err)
+	}
+
+	pool, isPool := db.(*bun.DB)
+	if !isPool {
+		return callback(ctx)
+	}
+
+	err = pool.RunInTx(ctx, opts, func(ctx context.Context, tx bun.Tx) error {
+		return callback(WithTx(ctx, tx))
+	})
+	if err != nil {
+		return fmt.Errorf("run in transaction: %w", err)
+	}
+
+	return nil
+}
+
+// A Transactor is the PostgreSQL implementation of
+// [github.com/a-novel-kit/golib/transaction.Transactor].
+type Transactor struct {
+	opts *sql.TxOptions
+}
+
+// NewTransactor returns a Transactor opening its transactions with opts. A nil
+// opts leaves the database defaults in place, which is read-committed
+// isolation.
+func NewTransactor(opts *sql.TxOptions) *Transactor {
+	return &Transactor{opts: opts}
+}
+
+// WithinTx satisfies [github.com/a-novel-kit/golib/transaction.Transactor].
+func (transactor *Transactor) WithinTx(ctx context.Context, fn func(ctx context.Context) error) error {
+	return WithinTx(ctx, transactor.opts, fn)
+}

--- a/postgres/transaction_test.go
+++ b/postgres/transaction_test.go
@@ -1,0 +1,218 @@
+package postgres_test
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
+
+	"github.com/a-novel-kit/golib/postgres"
+	postgrespresets "github.com/a-novel-kit/golib/postgres/presets"
+)
+
+// Migrations is the probe schema the transaction tests write to.
+//
+//go:embed testdata/migrations/*.sql
+var migrations embed.FS
+
+// errRollback is the failure a callback returns to trigger a rollback. It
+// stands for any error a real unit of work might raise; only its identity
+// matters.
+var errRollback = errors.New("rollback")
+
+// testConfig points the tests at a throwaway database, named by the same
+// environment variable production uses so a developer configures one thing.
+// There is no default: a wrong guess would silently target whatever happens to
+// listen on the usual port, and these tests write.
+func testConfig(t *testing.T) postgres.Config {
+	t.Helper()
+
+	dsn := os.Getenv("POSTGRES_DSN")
+	require.NotEmpty(t, dsn,
+		"POSTGRES_DSN must point at a throwaway database — this package wraps a real one and cannot be tested without it")
+
+	return postgrespresets.NewDefault(pgdriver.WithDSN(dsn))
+}
+
+// writeProbe inserts one row through GetContext — the same way every consumer's
+// data-access code resolves its handle. That is what makes these tests
+// meaningful: they exercise the path that silently escaped the transaction,
+// not a handle threaded in by the test itself.
+func writeProbe(ctx context.Context, t *testing.T, id string) {
+	t.Helper()
+
+	db, err := postgres.GetContext(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw("INSERT INTO transaction_probe (id) VALUES (?0)", id).Exec(ctx)
+	require.NoError(t, err)
+}
+
+func probeCount(ctx context.Context, t *testing.T, id string) int {
+	t.Helper()
+
+	db, err := postgres.GetContext(ctx)
+	require.NoError(t, err)
+
+	var count int
+
+	err = db.NewRaw("SELECT count(*) FROM transaction_probe WHERE id = ?0", id).Scan(ctx, &count)
+	require.NoError(t, err)
+
+	return count
+}
+
+// TestWithinTxRollback is the regression test for the defect this package
+// carried: it fails against an implementation that leaves the pool on the
+// context, because the insert would then commit on its own and outlive the
+// rollback.
+func TestWithinTxRollback(t *testing.T) {
+	t.Parallel()
+
+	id := "rollback"
+
+	postgres.RunDBTest(t, testConfig(t), migrations, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
+		err := postgres.WithinTx(ctx, nil, func(ctx context.Context) error {
+			writeProbe(ctx, t, id)
+
+			return errRollback
+		})
+		require.ErrorIs(t, err, errRollback)
+
+		require.Equal(t, 0, probeCount(ctx, t, id))
+	})
+}
+
+// TestRunInTxDoesNotCoverTheContext pins the deprecated function's behaviour.
+// It asserts the row SURVIVES a rolled-back transaction, which is not a mistake:
+// it documents, in the repository rather than in a review thread, exactly what
+// WithinTx was introduced to fix.
+//
+// It is expected to be deleted with RunInTx, not repaired.
+func TestRunInTxDoesNotCoverTheContext(t *testing.T) {
+	t.Parallel()
+
+	id := "run-in-tx-escape"
+
+	postgres.RunDBTest(t, testConfig(t), migrations, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
+		err := postgres.RunInTx(ctx, nil, func(ctx context.Context, _ bun.IDB) error {
+			writeProbe(ctx, t, id)
+
+			return errRollback
+		})
+		require.ErrorIs(t, err, errRollback)
+
+		require.Equal(t, 1, probeCount(ctx, t, id), "the write escaped the transaction and committed on its own")
+	})
+}
+
+func TestWithinTxCommit(t *testing.T) {
+	t.Parallel()
+
+	id := "commit"
+
+	postgres.RunDBTest(t, testConfig(t), migrations, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
+		err := postgres.WithinTx(ctx, nil, func(ctx context.Context) error {
+			writeProbe(ctx, t, id)
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, probeCount(ctx, t, id))
+	})
+}
+
+// TestWithinTxNested covers the joining rule: an inner failure discards the
+// outer unit of work, because the inner call takes part in the transaction
+// already in progress rather than opening a savepoint it could roll back alone.
+func TestWithinTxNested(t *testing.T) {
+	t.Parallel()
+
+	outer := "nested-outer"
+	inner := "nested-inner"
+
+	postgres.RunDBTest(t, testConfig(t), migrations, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
+		err := postgres.WithinTx(ctx, nil, func(ctx context.Context) error {
+			writeProbe(ctx, t, outer)
+
+			return postgres.WithinTx(ctx, nil, func(ctx context.Context) error {
+				writeProbe(ctx, t, inner)
+
+				return errRollback
+			})
+		})
+		require.ErrorIs(t, err, errRollback)
+
+		require.Equal(t, 0, probeCount(ctx, t, outer))
+		require.Equal(t, 0, probeCount(ctx, t, inner))
+	})
+}
+
+func TestTransactorDelegates(t *testing.T) {
+	t.Parallel()
+
+	id := "transactor"
+
+	postgres.RunDBTest(t, testConfig(t), migrations, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
+		err := postgres.NewTransactor(nil).WithinTx(ctx, func(ctx context.Context) error {
+			writeProbe(ctx, t, id)
+
+			return errRollback
+		})
+		require.ErrorIs(t, err, errRollback)
+
+		require.Equal(t, 0, probeCount(ctx, t, id))
+	})
+}
+
+func TestInTx(t *testing.T) {
+	t.Parallel()
+
+	postgres.RunDBTest(t, testConfig(t), migrations, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
+		require.False(t, postgres.InTx(ctx), "the pool is on the context outside a transaction")
+
+		err := postgres.WithinTx(ctx, nil, func(ctx context.Context) error {
+			require.True(t, postgres.InTx(ctx), "the transaction is on the context inside WithinTx")
+
+			return nil
+		})
+		require.NoError(t, err)
+	})
+}
+
+// TestInTxNoContext covers a context nothing seeded. InTx answers "is a
+// transaction open", and no database handle at all is not one.
+func TestInTxNoContext(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, postgres.InTx(t.Context()))
+}
+
+func TestWithinTxNoContext(t *testing.T) {
+	t.Parallel()
+
+	err := postgres.WithinTx(t.Context(), nil, func(context.Context) error {
+		t.Error("the callback must not run when the context carries no database")
+
+		return nil
+	})
+	require.ErrorIs(t, err, postgres.ErrNoIDBInContext)
+}

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -1,0 +1,44 @@
+// Package transaction declares the scope a unit of work runs in, independently
+// of what stores it.
+//
+// It exists as its own package, rather than alongside a driver, so that a
+// caller can name what it needs without gaining access to a database. Its
+// entire dependency list is context: nothing here can reach a connection, a
+// pool, or a driver symbol, which is what makes it safe to import from a layer
+// that is supposed to stay free of persistence detail.
+//
+// Implementations live with their driver — see
+// [github.com/a-novel-kit/golib/postgres.Transactor] for the PostgreSQL one.
+package transaction
+
+import "context"
+
+// A Transactor runs a unit of work atomically: every persistence call made with
+// the context it hands the callback either commits together or is rolled back
+// together.
+//
+// The callback receives no transaction handle. That is deliberate, and it is
+// the reason this interface exists rather than callers driving a driver
+// directly: a handle callers are expected to thread through every nested call
+// is a handle they can forget, and forgetting it fails silently — the calls run
+// outside the transaction, the block commits, and the tests pass. With nothing
+// to thread, the mistake cannot be written.
+//
+// Two behaviours are part of the contract, and an implementation that does not
+// honour them does not satisfy this interface.
+//
+// A nested WithinTx joins the transaction already in progress rather than
+// opening a nested one, so a rollback anywhere discards the whole outermost
+// unit of work. An inner operation that treats a failure as locally
+// recoverable is therefore discarding its caller's work too. Nesting is legal,
+// but it should be a deliberate choice rather than an accident of composition.
+//
+// Nothing that talks to an external service may run inside the callback. An
+// open transaction holds a pooled connection for as long as it lasts, and
+// pinning one for the length of a call to a third party exhausts the pool and
+// blocks reclamation of dead rows. Persist what the external call needs, close
+// the transaction, make the call, then open a new transaction to record the
+// result.
+type Transactor interface {
+	WithinTx(ctx context.Context, fn func(ctx context.Context) error) error
+}

--- a/transaction/transactiontest/transactor.go
+++ b/transaction/transactiontest/transactor.go
@@ -1,0 +1,66 @@
+// Package transactiontest provides an in-memory [transaction.Transactor] for
+// unit tests.
+//
+// A test substitutes *transactiontest.Transactor wherever a
+// [transaction.Transactor] is expected, so an operation under test runs its
+// body without a database while the test can still assert that the body ran
+// inside a transaction at all.
+//
+// It does not implement transactions. Nothing is rolled back, because there is
+// nothing to roll back — an in-memory double cannot undo whatever the callback
+// did to the fakes around it. What it verifies is that the caller opened a
+// scope and propagated the callback's outcome; that a rollback actually
+// discards writes is a property of the real implementation, and belongs in a
+// test that has a database.
+package transactiontest
+
+import (
+	"context"
+	"sync"
+)
+
+// A Transactor is an in-memory [transaction.Transactor] that runs the callback
+// inline and counts how many times it was entered. Safe for concurrent use.
+type Transactor struct {
+	err   error
+	calls int
+	mu    sync.Mutex
+}
+
+// NewTransactor returns a Transactor that runs every callback and returns
+// whatever the callback returns.
+func NewTransactor() *Transactor {
+	return &Transactor{}
+}
+
+// NewFailingTransactor returns a Transactor that refuses to run the callback at
+// all and returns err instead, standing in for a transaction that could not be
+// opened. The callback not running is the point: an operation that reports
+// success when its unit of work never started is the failure this reproduces.
+func NewFailingTransactor(err error) *Transactor {
+	return &Transactor{err: err}
+}
+
+// WithinTx satisfies [transaction.Transactor] by invoking fn with the context
+// it was given, unless the Transactor was built to fail.
+func (transactor *Transactor) WithinTx(ctx context.Context, fn func(ctx context.Context) error) error {
+	transactor.mu.Lock()
+	transactor.calls++
+	err := transactor.err
+	transactor.mu.Unlock()
+
+	if err != nil {
+		return err
+	}
+
+	return fn(ctx)
+}
+
+// Calls reports how many times WithinTx was entered, so a test can assert an
+// operation opened exactly one scope rather than one per write.
+func (transactor *Transactor) Calls() int {
+	transactor.mu.Lock()
+	defer transactor.mu.Unlock()
+
+	return transactor.calls
+}

--- a/transaction/transactiontest/transactor_test.go
+++ b/transaction/transactiontest/transactor_test.go
@@ -1,0 +1,82 @@
+package transactiontest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/transaction"
+	"github.com/a-novel-kit/golib/transaction/transactiontest"
+)
+
+var errTest = errors.New("test")
+
+func TestTransactorRunsTheCallback(t *testing.T) {
+	t.Parallel()
+
+	transactor := transactiontest.NewTransactor()
+	ran := false
+
+	err := transactor.WithinTx(t.Context(), func(context.Context) error {
+		ran = true
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.True(t, ran)
+	require.Equal(t, 1, transactor.Calls())
+}
+
+func TestTransactorPropagatesTheCallbackError(t *testing.T) {
+	t.Parallel()
+
+	transactor := transactiontest.NewTransactor()
+
+	err := transactor.WithinTx(t.Context(), func(context.Context) error {
+		return errTest
+	})
+	require.ErrorIs(t, err, errTest)
+}
+
+// TestFailingTransactorSkipsTheCallback covers the property the failing double
+// exists for: an operation that reports success when its unit of work never
+// started is the bug it reproduces, so the callback must not run.
+func TestFailingTransactorSkipsTheCallback(t *testing.T) {
+	t.Parallel()
+
+	transactor := transactiontest.NewFailingTransactor(errTest)
+
+	err := transactor.WithinTx(t.Context(), func(context.Context) error {
+		t.Error("the callback ran despite the transaction failing to open")
+
+		return nil
+	})
+	require.ErrorIs(t, err, errTest)
+	require.Equal(t, 1, transactor.Calls())
+}
+
+func TestTransactorCountsNestedCalls(t *testing.T) {
+	t.Parallel()
+
+	transactor := transactiontest.NewTransactor()
+
+	err := transactor.WithinTx(t.Context(), func(ctx context.Context) error {
+		return transactor.WithinTx(ctx, func(context.Context) error {
+			return nil
+		})
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, transactor.Calls())
+}
+
+// TestTransactorSatisfiesTheInterface fails to compile rather than fails to
+// run if the double drifts from the contract it stands in for.
+func TestTransactorSatisfiesTheInterface(t *testing.T) {
+	t.Parallel()
+
+	var transactor transaction.Transactor = transactiontest.NewTransactor()
+
+	require.NoError(t, transactor.WithinTx(t.Context(), func(context.Context) error { return nil }))
+}


### PR DESCRIPTION
## Summary

- `RunInTx` hands its callback the **original** context, still carrying the pool. Anything inside that resolves its handle with `GetContext` — which is how every service's data-access code works — commits independently of the transaction that appears to wrap it. Nothing fails, nothing logs, and the block reports success. Four core operations in `service-authentication` are in exactly that state today, green on both sides.
- Adds `WithinTx`, whose callback takes **no transaction argument**. That is the fix, not a style preference: a handle callers must thread through every nested call is a handle they can forget, and with nothing to thread the only database handle reachable inside the callback is the transactional one. The mistake becomes unwritable rather than merely documented against.
- Adds a `transaction` package holding one interface, `Transactor`, whose entire dependency list is `context`. Business code imports it to require atomicity without gaining any way to reach a driver — atomicity is not a PostgreSQL idea, so it does not live under a driver package. `postgres.Transactor` implements it.
- Stands a database up in the `test-go` job. The `postgres` package wraps a real database and had **no tests at all**; it ships `RunDBTest` and `RunTransactionalTest` for its consumers and never used them on itself. That is a fair part of why a transaction helper that never opened a transaction survived here.

Closes #369

## What to scrutinise

**The regression test was verified to fail against the defect, twice.** Reverting `WithinTx` to forward `ctx` unchanged — literally reproducing `RunInTx` — fails `TestWithinTxRollback`, `TestWithinTxNested`, `TestInTx` and `TestTransactorDelegates`, while `TestWithinTxCommit` stays green. Re-checked after the fixtures changed, since a rollback test that passes either way is worthless.

`TestRunInTxDoesNotCoverTheContext` asserts a row **survives** a rolled-back `RunInTx`. That is deliberate: it documents the deprecation's reason in the repository rather than in a review thread, and it is expected to be deleted alongside `RunInTx` rather than repaired.

**Three names, not two.** `WithTx` installs, `WithinTx` runs, `InTx` asks. An earlier draft of the issue gave the runner and the predicate the same name — the same shape as the `tx` variable that names a connection pool in several services, which is how the original defect stayed invisible.

**Nesting joins rather than opening a savepoint**, so one unit of work has one outcome — and a nested call therefore never sees its own `sql.TxOptions`. Both are on the interface's doc comment as contract, not as implementation detail.

**Zero new dependencies.** The test fixtures originally used `google/uuid`, which promoted it from indirect to direct; text ids removed that. `go.mod` and `go.sum` are unchanged.

## Breaking changes

None. `RunInTx` keeps working exactly as before and is only marked deprecated; consumers migrate on their own schedule, each under its own issue.

## Commit hygiene

The README row landed inside the `feat(postgres)` commit rather than its own — the index still held it after an unpushed reset, and it was noticed after pushing. Not rewritten, per the never-amend-a-pushed-commit rule.

## Test plan

- [x] `go test ./...` passes against a real Postgres 18.4
- [x] `pnpm lint:go` and `pnpm lint:prettier` clean
- [x] Regression verified failing against the pre-fix behaviour
- [x] `go.mod` / `go.sum` unchanged
- [ ] CI green