### PR TITLE
refactor(postgres)!: remove RunInTx

### DIFF
--- a/docs/migrations/v0.24.0.md
+++ b/docs/migrations/v0.24.0.md
@@ -1,0 +1,100 @@
+# Migrating to v0.24.0
+
+`postgres.RunInTx` is removed. Use `postgres.WithinTx`, or take a
+`transaction.Transactor` as a dependency.
+
+## Why it went away rather than being fixed
+
+`RunInTx` opened a real transaction and then handed its callback the **original**
+context — the one still carrying the connection pool. Data-access code that
+resolves its handle with `postgres.GetContext`, which is how every service in the
+organisation works, therefore got the pool back and committed independently of
+the transaction wrapped around it.
+
+Only calls made through the `tx` argument took part. A caller who passed `ctx`
+down instead — the natural thing to do, since every other function takes a
+context — ended up with a block that opened a transaction, committed it, and
+protected nothing. No error, no log, no failing test.
+
+That is not a bug the signature could keep: a handle you are expected to thread
+through every nested call is a handle you can forget. `WithinTx` takes no
+transaction argument at all, so there is nothing to forget and the only database
+handle reachable inside the callback is the transactional one.
+
+## Mechanical replacement
+
+The common case is a callback that already passes `ctx` down. It was silently
+not atomic; it now is, and the change is the signature only.
+
+```go
+// before
+err := postgres.RunInTx(ctx, nil, func(ctx context.Context, tx bun.IDB) error {
+	return doWork(ctx)
+})
+
+// after
+err := postgres.WithinTx(ctx, nil, func(ctx context.Context) error {
+	return doWork(ctx)
+})
+```
+
+## When the callback actually used its `tx`
+
+Those calls were the ones genuinely inside the transaction, so they must keep
+working. Resolve the handle from the context instead — it is the transaction
+now:
+
+```go
+// before
+err := postgres.RunInTx(ctx, opts, func(ctx context.Context, tx bun.IDB) error {
+	_, err := tx.NewRaw(query, arg).Exec(ctx)
+	return err
+})
+
+// after
+err := postgres.WithinTx(ctx, opts, func(ctx context.Context) error {
+	tx, err := postgres.GetContext(ctx)
+	if err != nil {
+		return fmt.Errorf("get database handle: %w", err)
+	}
+
+	_, err = tx.NewRaw(query, arg).Exec(ctx)
+
+	return err
+})
+```
+
+## Prefer the injected scope in business code
+
+`WithinTx` is a package call, so code that uses it cannot be tested for
+atomicity and has to import a driver package to say "these writes belong
+together". Take the port instead, and let the composition root supply the
+implementation:
+
+```go
+// business layer — names no database
+type Service struct {
+	transactor transaction.Transactor
+}
+
+err := service.transactor.WithinTx(ctx, func(ctx context.Context) error { ... })
+
+// composition root
+service := NewService(postgres.NewTransactor(nil))
+```
+
+`transactiontest.NewTransactor` runs the callback inline for unit tests, and
+`NewFailingTransactor` refuses to open — which is how a test proves the writes
+are inside the scope rather than merely near it.
+
+## Two behaviours worth knowing before you migrate
+
+**Nesting joins.** A `WithinTx` inside another one takes part in the transaction
+already in progress rather than opening a savepoint, so a rollback anywhere
+discards the whole outermost unit of work. `RunInTx` behaved differently here.
+
+**A nested call never sees its own options.** Because it joins, its
+`sql.TxOptions` are ignored — an operation that depends on a specific isolation
+level must be the outermost transaction, or refuse to run nested at all.
+`postgres.InTx(ctx)` reports whether one is already open, which is how a caller
+makes that refusal explicit instead of silently degrading.

--- a/postgres/context.go
+++ b/postgres/context.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 
@@ -54,30 +53,6 @@ func GetContext(ctx context.Context) (bun.IDB, error) {
 	}
 
 	return db, nil
-}
-
-// RunInTx runs callback within a transaction opened on the connection carried
-// by ctx. The callback receives the transaction as a bun.IDB.
-//
-// The context it hands the callback is the original one, still carrying the
-// pool — so anything inside that resolves its handle with [GetContext] gets the
-// pool back and commits independently of the surrounding transaction, silently.
-// Only calls made through the tx argument take part, and a caller who threads
-// ctx instead has a block that opens a transaction, commits it, and protects
-// nothing. Nothing about that fails or logs.
-//
-// Deprecated: use [WithinTx], whose callback takes no transaction argument
-// because the transaction is installed on the context it receives. With nothing
-// to thread, the mistake above cannot be written.
-func RunInTx(ctx context.Context, opts *sql.TxOptions, callback func(ctx context.Context, tx bun.IDB) error) error {
-	db, err := GetContext(ctx)
-	if err != nil {
-		return fmt.Errorf("get db from context: %w", err)
-	}
-
-	return db.RunInTx(ctx, opts, func(ctx context.Context, tx bun.Tx) error {
-		return callback(ctx, tx)
-	})
 }
 
 // TransferContext transfers the current postgres context into another. If the source context is not a postgres

--- a/postgres/transaction_test.go
+++ b/postgres/transaction_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/driver/pgdriver"
 
 	"github.com/a-novel-kit/golib/postgres"
@@ -87,31 +86,6 @@ func TestWithinTxRollback(t *testing.T) {
 		require.ErrorIs(t, err, errRollback)
 
 		require.Equal(t, 0, probeCount(ctx, t, id))
-	})
-}
-
-// TestRunInTxDoesNotCoverTheContext pins the deprecated function's behaviour.
-// It asserts the row SURVIVES a rolled-back transaction, which is not a mistake:
-// it documents, in the repository rather than in a review thread, exactly what
-// WithinTx was introduced to fix.
-//
-// It is expected to be deleted with RunInTx, not repaired.
-func TestRunInTxDoesNotCoverTheContext(t *testing.T) {
-	t.Parallel()
-
-	id := "run-in-tx-escape"
-
-	postgres.RunDBTest(t, testConfig(t), migrations, func(ctx context.Context, t *testing.T) {
-		t.Helper()
-
-		err := postgres.RunInTx(ctx, nil, func(ctx context.Context, _ bun.IDB) error {
-			writeProbe(ctx, t, id)
-
-			return errRollback
-		})
-		require.ErrorIs(t, err, errRollback)
-
-		require.Equal(t, 1, probeCount(ctx, t, id), "the write escaped the transaction and committed on its own")
 	})
 }
 


### PR DESCRIPTION
## Summary

Removes `postgres.RunInTx`, the contract half of the staged rollout that began in v0.23.0: add the new path, migrate every consumer, remove the old one. A deprecated symbol that stays exported is one an autocomplete still offers — and this one costs atomicity without saying so.

Adds `docs/migrations/v0.24.0.md`, because the two calls are not interchangeable: the callback loses its `tx` parameter, and a call site that genuinely used it has to resolve the handle from the context instead.

Closes #375

## Ready — every consumer is off it

a-novel/service-json-keys#833 merged, so the last caller is gone. Verified against each service'''s
master rather than assumed:

```
git grep -n "RunInTx" origin/master -- '''*.go'''
```

| Consumer | Result |
|---|---|
| `service-narrative-engine` | clean |
| `service-authentication` | clean |
| `service-json-keys` | clean |
| `service-template` | clean |

## What to scrutinise

**`TestRunInTxDoesNotCoverTheContext` is deleted, not repaired.** It asserted a row *survives* a rolled-back transaction — documenting why the deprecation existed. With the function gone it would invert, and an inverted test left in place reads as a regression to whoever finds it next.

**`PassthroughTx.RunInTx` stays.** It implements `bun.IDB`, so it is bun's method, not this package's — unrelated to the function being removed despite the matching name.

**Version.** `golib` is a `v0` module, so a breaking change is a minor bump: **v0.24.0**, matching the migration guide's filename.

## Breaking changes

`postgres.RunInTx` is removed. Migration guide: `docs/migrations/v0.24.0.md`. Everything it breaks is in-organization and listed above.

## Test plan

- [x] `go test ./...` passes against a real Postgres 18.4
- [x] `pnpm lint:go` and `pnpm lint:prettier` clean
- [x] No remaining callers anywhere in the workspace
- [ ] json-keys#833 merged
- [ ] CI green