### PR TITLE
feat(smtp): bound every delivery with a timeout

### DIFF
--- a/docs/migrations/v0.25.0.md
+++ b/docs/migrations/v0.25.0.md
@@ -1,10 +1,13 @@
 # Migrating to v0.25.0
 
-Nothing to change. This note exists because the release alters how many database
-connections a process holds, which is a capacity question worth deciding
-deliberately rather than discovering.
+Nothing to change. This note exists because the release alters two defaults, each
+of which is a decision worth making deliberately rather than discovering.
 
-## What changed
+Neither was ever anyone's answer: both are what the standard library does when
+nobody says otherwise, leaking through presets that are otherwise opinionated. And
+neither reported anything — no error, no log, no failing test.
+
+## Idle database connections
 
 `postgrespresets.Default` now keeps up to **ten** idle connections per pool. It
 previously kept whatever `database/sql` defaults to, which is **two**.
@@ -16,7 +19,7 @@ handshake and a PostgreSQL authentication exchange) and discarded it on release.
 Nothing reported that: no error, no log, no failing test. It was a latency floor
 under every query in every service.
 
-## The capacity arithmetic, which is the reason to read this
+### The capacity arithmetic, which is the reason to read this
 
 The limit is **per process**. What has to stay under the database's
 `max_connections` is the sum across every replica plus any job that connects:
@@ -29,7 +32,7 @@ A stock PostgreSQL allows 100. Ten replicas of one service now sit at 100 idle
 connections on their own. If a deployment runs more replicas than that arithmetic
 allows, either raise `max_connections` or lower the pool.
 
-## Overriding it
+### Overriding it
 
 The field is on the config, so it is set where the config is built:
 
@@ -41,9 +44,62 @@ config.MaxIdleConns = 4   // or a negative value to keep none, as before
 Zero means the default. A negative value keeps no idle connections, matching
 `database/sql`, and is the way back to the old behaviour if a deployment needs it.
 
-## What deliberately did not change
+### What deliberately did not change
 
 The maximum number of **open** connections. That depends on how many replicas run
 against one database and how hard they are driven, which is a service's decision
 rather than a library's — services set it themselves, from configuration, when
 they build the pool.
+
+## SMTP delivery timeout
+
+`smtp.ProdSender` now bounds every delivery. A send or a `Ping` that previously
+could hang forever now fails after `smtp.DefaultTimeout` (30 seconds).
+
+### Why the default is bounded rather than opt-in
+
+`net/smtp` dials with no deadline and offers no cancellation. An SMTP host that
+accepts the connection and then goes quiet — a security-group change, a provider
+throttling by stalling rather than refusing — held the calling goroutine forever.
+
+Nothing reported it. Where the send is detached from its request (the usual shape,
+so delivery survives request cancellation), the HTTP response has already been
+written by the time the goroutine blocks: no latency signal, no error rate, no
+failing probe. The only symptom is a slow climb in memory, and `Ping` — the
+readiness check that exists to report a broken SMTP server — hung too, so the one
+signal an operator would look at is the one the failure disables.
+
+A timeout that must be opted into is a timeout that is eventually forgotten, and
+forgetting it is silent. So the bound applies by default.
+
+### Overriding it
+
+If your SMTP provider legitimately takes longer than 30 seconds to accept a
+message, set the new field:
+
+```go
+sender := &smtp.ProdSender{
+    Addr:  cfg.Addr,
+    Email: cfg.Email,
+    // Connect, handshake, authentication and the message body share this budget.
+    Timeout: 60 * time.Second,
+}
+```
+
+A non-positive `Timeout` selects `DefaultTimeout`. There is no value meaning
+"unbounded" — that is the state this release removes.
+
+### Also new
+
+`smtp.ErrNoAuthSupport` is returned when the server does not advertise the `AUTH`
+extension. The standard library raised an unwrapped error here; the sentinel makes
+it matchable with `errors.Is`. This is not a behaviour change — such a server was
+already rejected.
+
+### Under the hood
+
+`ProdSender` now drives the SMTP exchange itself instead of calling
+`smtp.SendMail`, because `SendMail` dials internally and so cannot be bounded by
+the caller. The handshake is a transcription of what it does, in the same order:
+`STARTTLS` whenever the server offers it, **before** any credential is sent, then
+`AUTH`. Nothing about which servers are accepted changes.

--- a/smtp/sender.prod.go
+++ b/smtp/sender.prod.go
@@ -2,10 +2,29 @@ package smtp
 
 import (
 	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
 	"fmt"
+	"net"
 	"net/smtp"
 	"text/template"
+	"time"
 )
+
+// DefaultTimeout bounds a single delivery when ProdSender leaves Timeout unset.
+//
+// Bounded rather than unlimited on purpose. net/smtp dials with no deadline, so an SMTP host that
+// accepts the connection and then goes quiet — a security-group change, a provider throttling by
+// stalling — holds the calling goroutine forever. A caller who must remember to set a timeout is a
+// caller who eventually forgets, and the resulting leak reports nothing: the request that spawned
+// the send has already returned, so there is no latency signal, no error rate and no failing probe.
+// Only a slow climb in memory.
+const DefaultTimeout = 30 * time.Second
+
+// ErrNoAuthSupport is returned when the server does not advertise the AUTH extension. Continuing
+// would mean either skipping authentication or offering credentials the server never asked for.
+var ErrNoAuthSupport = errors.New("SMTP server does not support AUTH")
 
 // ProdSender delivers mail through a real SMTP server using net/smtp. Its
 // fields are populated from configuration; the password is never serialized
@@ -22,8 +41,18 @@ type ProdSender struct {
 	// server has not secured with TLS, sending credentials in the clear. Use it
 	// only against a local test SMTP server; never enable it in production.
 	ForceUnencryptedTls bool `json:"forceUnencryptedTLS" yaml:"forceUnencryptedTLS"`
+
+	// Timeout bounds one delivery end to end. Connect, handshake, authentication and the message
+	// body share a single budget, because a stalled server can hold any of those steps.
+	// Non-positive selects DefaultTimeout.
+	Timeout time.Duration `json:"timeout" yaml:"timeout"`
 }
 
+// SendMail renders tName from t with data and delivers it, driving the SMTP exchange directly.
+//
+// [smtp.SendMail] would be the obvious call, and this is a transcription of what it does — but it
+// dials internally with no deadline, so nothing a caller can do bounds the exchange once the
+// connection is accepted.
 func (sender *ProdSender) SendMail(to MailUsers, t *template.Template, tName string, data any) error {
 	writer := bytes.NewBuffer(nil)
 
@@ -32,16 +61,52 @@ func (sender *ProdSender) SendMail(to MailUsers, t *template.Template, tName str
 		return fmt.Errorf("execute template err: %w", err)
 	}
 
-	auth := smtp.PlainAuth(sender.Name, sender.Email, sender.Password, sender.Domain)
-	if sender.ForceUnencryptedTls {
-		auth = unencryptedAuth{auth}
-	}
-
 	msg := fmt.Sprintf("From: %s <%s>\r\n", sender.Name, sender.Email)
 	msg += fmt.Sprintf("To: %s\r\n", to.String())
 	msg += writer.String()
 
-	err = smtp.SendMail(sender.Addr, auth, sender.Email, to.Emails(), []byte(msg))
+	client, host, err := sender.dial()
+	if err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+
+	defer func() { _ = client.Close() }()
+
+	err = sender.negotiate(client, host)
+	if err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+
+	err = client.Mail(sender.Email)
+	if err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+
+	for _, addr := range to.Emails() {
+		err = client.Rcpt(addr)
+		if err != nil {
+			return fmt.Errorf("send email: %w", err)
+		}
+	}
+
+	body, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+
+	_, err = body.Write([]byte(msg))
+	if err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+
+	// Closing the body is what commits the message, so its error is the server's verdict on the
+	// delivery — not the droppable error of a cleanup close.
+	err = body.Close()
+	if err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+
+	err = client.Quit()
 	if err != nil {
 		return fmt.Errorf("send email: %w", err)
 	}
@@ -49,29 +114,114 @@ func (sender *ProdSender) SendMail(to MailUsers, t *template.Template, tName str
 	return nil
 }
 
+// Ping reports whether the SMTP server is reachable and accepts the configured credentials. It
+// shares SendMail's timeout: a readiness probe that can hang is one that reports nothing about the
+// very outage it exists to detect.
 func (sender *ProdSender) Ping() error {
-	auth := smtp.PlainAuth(sender.Name, sender.Email, sender.Password, sender.Domain)
-	if sender.ForceUnencryptedTls {
-		auth = unencryptedAuth{auth}
-	}
-
-	conn, err := smtp.Dial(sender.Addr)
+	client, host, err := sender.dial()
 	if err != nil {
-		return fmt.Errorf("dial SMTP server: %w", err)
+		return err
 	}
 
-	defer func() {
-		_ = conn.Close()
-	}()
+	defer func() { _ = client.Close() }()
 
-	err = conn.Auth(auth)
+	err = sender.negotiate(client, host)
 	if err != nil {
-		return fmt.Errorf("authenticate with SMTP server: %w", err)
+		return err
 	}
 
-	err = conn.Quit()
+	err = client.Quit()
 	if err != nil {
 		return fmt.Errorf("quit SMTP connection: %w", err)
+	}
+
+	return nil
+}
+
+func (sender *ProdSender) timeout() time.Duration {
+	if sender.Timeout <= 0 {
+		return DefaultTimeout
+	}
+
+	return sender.Timeout
+}
+
+func (sender *ProdSender) auth() smtp.Auth {
+	auth := smtp.PlainAuth(sender.Name, sender.Email, sender.Password, sender.Domain)
+	if sender.ForceUnencryptedTls {
+		return unencryptedAuth{auth}
+	}
+
+	return auth
+}
+
+// dial connects to the SMTP server with the delivery's deadline already set on the connection.
+//
+// The deadline is the whole reason for dialing here rather than through [smtp.SendMail] or
+// [smtp.Dial]: both dial internally with no deadline, so a caller cannot bound what happens once the
+// connection is accepted. net/smtp offers no context and no cancellation, which leaves the
+// connection's own deadline as the only mechanism reaching every subsequent read and write.
+//
+// The dialer takes a background context because [Sender] carries none; the timeout, not the context,
+// is what bounds this.
+func (sender *ProdSender) dial() (*smtp.Client, string, error) {
+	timeout := sender.timeout()
+
+	host, _, err := net.SplitHostPort(sender.Addr)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse SMTP address: %w", err)
+	}
+
+	dialer := &net.Dialer{Timeout: timeout}
+
+	conn, err := dialer.DialContext(context.Background(), "tcp", sender.Addr)
+	if err != nil {
+		return nil, "", fmt.Errorf("dial SMTP server: %w", err)
+	}
+
+	// Measured from here, so the budget covers the whole exchange rather than restarting per step.
+	err = conn.SetDeadline(time.Now().Add(timeout))
+	if err != nil {
+		_ = conn.Close()
+
+		return nil, "", fmt.Errorf("set SMTP deadline: %w", err)
+	}
+
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		_ = conn.Close()
+
+		return nil, "", fmt.Errorf("open SMTP client: %w", err)
+	}
+
+	return client, host, nil
+}
+
+// negotiate performs the handshake [smtp.SendMail] would have done: upgrade to TLS whenever the
+// server offers it, then authenticate, refusing to continue when the server does not advertise AUTH.
+//
+// The ordering is the security-relevant part and matches the standard library's: STARTTLS is
+// attempted before any credential is offered, so an eavesdropper sees the upgrade rather than the
+// password.
+func (sender *ProdSender) negotiate(client *smtp.Client, host string) error {
+	ok, _ := client.Extension("STARTTLS")
+	if ok {
+		config := &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12}
+
+		err := client.StartTLS(config)
+		if err != nil {
+			return fmt.Errorf("start TLS: %w", err)
+		}
+	}
+
+	ok, _ = client.Extension("AUTH")
+	if !ok {
+		return ErrNoAuthSupport
+	}
+
+	err := client.Auth(sender.auth())
+	if err != nil {
+		return fmt.Errorf("authenticate with SMTP server: %w", err)
 	}
 
 	return nil

--- a/smtp/sender.prod_test.go
+++ b/smtp/sender.prod_test.go
@@ -1,0 +1,294 @@
+package smtp_test
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/smtp"
+)
+
+// ProdSender drives the SMTP exchange itself rather than calling net/smtp.SendMail, because
+// SendMail dials internally and so cannot be bounded. That transcription is what these tests cover:
+// the handshake still happens in the right order, and — the reason for the change — a server that
+// accepts a connection and then goes quiet no longer holds the caller forever.
+//
+// The fake server is a real listener speaking enough SMTP to complete a transaction, so the client
+// under test is the real net/smtp client on a real socket.
+
+// fakeServer is a minimal SMTP server for one connection.
+type fakeServer struct {
+	listener net.Listener
+	// stall makes the server accept the connection and then never write a greeting, which is the
+	// failure mode the timeout exists for: the dial succeeds, so no dial timeout can help.
+	stall bool
+	// transcript records the commands the client sent, in order.
+	transcript []string
+	// stop releases a stalled handler at cleanup; done reports that serve has returned. Separate
+	// channels on purpose — a stalled handler waiting on the one its own defer closes would
+	// deadlock against the cleanup waiting for it.
+	stop chan struct{}
+	done chan struct{}
+}
+
+func newFakeServer(t *testing.T, stall bool) *fakeServer {
+	t.Helper()
+
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &fakeServer{
+		listener: listener,
+		stall:    stall,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+
+	go server.serve()
+
+	t.Cleanup(func() {
+		close(server.stop)
+
+		_ = listener.Close()
+
+		<-server.done
+	})
+
+	return server
+}
+
+func (s *fakeServer) addr() string { return s.listener.Addr().String() }
+
+func (s *fakeServer) serve() {
+	defer close(s.done)
+
+	conn, err := s.listener.Accept()
+	if err != nil {
+		return
+	}
+
+	defer func() { _ = conn.Close() }()
+
+	if s.stall {
+		// Accept and say nothing. Without a deadline on the connection the client waits here
+		// indefinitely for a greeting that never comes.
+		<-s.stop
+
+		return
+	}
+
+	reader := bufio.NewReader(conn)
+	write := func(line string) { _, _ = conn.Write([]byte(line + "\r\n")) }
+
+	write("220 fake ESMTP")
+
+	inData := false
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+
+		if inData {
+			if line == "." {
+				inData = false
+
+				write("250 2.0.0 Ok")
+			}
+
+			continue
+		}
+
+		s.transcript = append(s.transcript, line)
+
+		switch {
+		case strings.HasPrefix(line, "EHLO"):
+			// AUTH is advertised; STARTTLS deliberately is not, so the client must skip the upgrade
+			// rather than fail. PlainAuth permits plaintext credentials to a loopback server.
+			write("250-fake")
+			write("250 AUTH PLAIN")
+		case strings.HasPrefix(line, "AUTH"):
+			write("235 2.7.0 Accepted")
+		case strings.HasPrefix(line, "MAIL FROM"), strings.HasPrefix(line, "RCPT TO"):
+			write("250 2.0.0 Ok")
+		case strings.HasPrefix(line, "DATA"):
+			inData = true
+
+			write("354 End data with <CR><LF>.<CR><LF>")
+		case strings.HasPrefix(line, "QUIT"):
+			write("221 2.0.0 Bye")
+
+			return
+		default:
+			write("250 2.0.0 Ok")
+		}
+	}
+}
+
+func testTemplate(t *testing.T) *template.Template {
+	t.Helper()
+
+	tmpl, err := template.New("mail").Parse("hello {{ . }}")
+	require.NoError(t, err)
+
+	return tmpl
+}
+
+func TestProdSenderSendMail(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer(t, false)
+
+	host, _, err := net.SplitHostPort(server.addr())
+	require.NoError(t, err)
+
+	sender := &smtp.ProdSender{
+		Addr:  server.addr(),
+		Name:  "Agora",
+		Email: "noreply@example.com",
+		// The fake accepts any credential; what matters is that AUTH is attempted at all.
+		Password: "hunter2",
+		// PlainAuth checks this against the server it is talking to, so Domain is the SMTP host
+		// rather than the mail domain — a pre-existing coupling this change does not alter.
+		Domain: host,
+	}
+
+	err = sender.SendMail(
+		smtp.MailUsers{{Name: "Recipient", Email: "to@example.com"}},
+		testTemplate(t), "mail", "world",
+	)
+	require.NoError(t, err)
+
+	joined := strings.Join(server.transcript, "\n")
+	require.Contains(t, joined, "AUTH PLAIN", "credentials must be offered")
+	require.Contains(t, joined, "MAIL FROM:<noreply@example.com>")
+	require.Contains(t, joined, "RCPT TO:<to@example.com>")
+	require.Contains(t, joined, "DATA")
+	require.Contains(t, joined, "QUIT")
+
+	// AUTH before MAIL: the transcription must not start a transaction unauthenticated.
+	authAt := strings.Index(joined, "AUTH")
+	mailAt := strings.Index(joined, "MAIL FROM")
+	require.Less(t, authAt, mailAt, "AUTH must precede MAIL FROM")
+}
+
+func TestProdSenderRefusesServerWithoutAuth(t *testing.T) {
+	t.Parallel()
+
+	// A server advertising no AUTH would previously have had credentials skipped silently; the
+	// send must fail rather than deliver unauthenticated.
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+
+		defer func() { _ = conn.Close() }()
+
+		reader := bufio.NewReader(conn)
+
+		_, _ = conn.Write([]byte("220 fake ESMTP\r\n"))
+
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				return
+			}
+
+			if strings.HasPrefix(line, "EHLO") {
+				_, _ = conn.Write([]byte("250 fake\r\n")) // no extensions at all
+
+				continue
+			}
+
+			_, _ = conn.Write([]byte("221 Bye\r\n"))
+
+			return
+		}
+	}()
+
+	sender := &smtp.ProdSender{Addr: listener.Addr().String(), Email: "noreply@example.com"}
+
+	err = sender.SendMail(
+		smtp.MailUsers{{Name: "R", Email: "to@example.com"}},
+		testTemplate(t), "mail", "world",
+	)
+	require.ErrorIs(t, err, smtp.ErrNoAuthSupport)
+}
+
+func TestProdSenderTimesOutOnStalledServer(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer(t, true)
+
+	sender := &smtp.ProdSender{
+		Addr:    server.addr(),
+		Email:   "noreply@example.com",
+		Timeout: 150 * time.Millisecond,
+	}
+
+	// The connection is accepted, so a dial timeout would not help — only a deadline on the
+	// connection bounds the wait for a greeting that never arrives. Without one this blocks
+	// forever, and the goroutine holding it is invisible: the HTTP request that spawned it has
+	// already returned 202.
+	start := time.Now()
+
+	err := sender.SendMail(
+		smtp.MailUsers{{Name: "R", Email: "to@example.com"}},
+		testTemplate(t), "mail", "world",
+	)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+
+	var netErr net.Error
+
+	require.True(t, errors.As(err, &netErr) && netErr.Timeout(), "expected a timeout, got %v", err)
+	require.Less(t, elapsed, 5*time.Second, "the send must return on its own deadline")
+}
+
+func TestProdSenderPingTimesOutOnStalledServer(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeServer(t, true)
+
+	// Ping backs the readiness probe. Unbounded, the probe that exists to report a broken SMTP
+	// server hangs instead of reporting it — so the one signal an operator would look at is the
+	// one the failure disables.
+	sender := &smtp.ProdSender{
+		Addr:    server.addr(),
+		Email:   "noreply@example.com",
+		Timeout: 150 * time.Millisecond,
+	}
+
+	start := time.Now()
+	err := sender.Ping()
+
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 5*time.Second)
+}
+
+func TestProdSenderDefaultTimeoutApplies(t *testing.T) {
+	t.Parallel()
+
+	// An unset Timeout must not mean "unbounded" — that is the config every caller forgets.
+	sender := &smtp.ProdSender{Addr: "192.0.2.1:25", Email: "noreply@example.com"}
+
+	require.Positive(t, smtp.DefaultTimeout)
+
+	_ = sender // the constant is the contract; dialing TEST-NET-1 here would cost DefaultTimeout
+}


### PR DESCRIPTION
The golib half of a-novel/service-authentication#1112. That issue is "`SMTP_TIMEOUT` is loaded,
documented, plumbed into config and enforced by nothing" — and it cannot be enforced service-side,
because the thing it must bound lives here.

## Why the service could not fix this itself

`net/smtp` has no context and no cancellation. A service-side `context.WithTimeout` around the send
reports the failure but does not stop the work: the goroutine stays blocked in the same syscall. It
converts unbounded *growth* into bounded *reporting*, which is not the defect.

The only mechanism that reaches every read and write is a deadline on the connection — and
`smtp.SendMail` dials internally, so a caller never holds the connection to set one.

## What that costs

`ProdSender` now drives the exchange itself. The handshake is a transcription of `SendMail`'s, in the
same order, using only exported API:

```
Extension("STARTTLS") → StartTLS   (before any credential is offered)
Extension("AUTH")     → Auth
Mail → Rcpt… → Data → Quit
```

`SendMail`'s own body cannot be copied — it uses unexported internals (`c.hello()`, `c.ext`,
`c.serverName`) — so the equivalents are `Extension` and the host parsed from `Addr`.

**This is the part to review closely.** Getting the order wrong would send credentials before the TLS
upgrade. The transaction test asserts `AUTH` precedes `MAIL FROM`, and a second test asserts a server
advertising no `AUTH` is refused outright rather than delivered to unauthenticated.

## Bounded by default, not opt-in

`DefaultTimeout` is 30s and a non-positive `Timeout` selects it. There is no value meaning
"unbounded".

A timeout a caller must remember to set is one that is eventually forgotten, and forgetting it is
silent — the request that spawned the detached send has already returned, so there is no latency
signal, no error rate, and `Ping` (the readiness probe that exists to report a broken SMTP server)
hangs too. The one signal an operator would look at is the one the failure disables.

That is a behaviour change on upgrade, so `docs/migrations/v0.25.0.md` says so.

## Test plan

The package had **no test for `ProdSender`** — `smtptest` fakes the `Sender` interface, not a server,
so there was nothing to verify a protocol transcription against. This adds a minimal SMTP server on a
real listener, so the client under test is the real `net/smtp` client on a real socket.

- [x] **The stalled-server cases hang until Go's own test timeout kills them without the connection
      deadline** (verified by removing it — 30s, killed by the framework), and return in 150ms with it.
      The server accepts and then goes silent, so a dial timeout cannot help.
- [x] `Ping` is bounded too
- [x] The transaction reaches `AUTH`, `MAIL FROM`, `RCPT TO`, `DATA`, `QUIT`, with `AUTH` before
      `MAIL FROM`
- [x] A server advertising no `AUTH` yields `ErrNoAuthSupport`
- [x] `golangci-lint v2.12.2` reports 0 issues across the module
- [ ] CI green

**Note on the local suite:** `postgres`'s `TestWithinTx*` / `TestInTx` fail on my machine for want of
`POSTGRES_DSN`, identically on clean `master`, and CI is green there. Unrelated to this change.

## Next

Once released (**v0.25.0** — additive `feat`), `service-authentication` re-pins and wires
`cfg.Smtp.Timeout` through, which closes #1112 and unblocks #1111 (the shutdown drain, which must not
land against an unbounded send or it converts dropped mail into a hung shutdown).