### PR TITLE
feat(postgres): let the preset carry the pool limits

### DIFF
--- a/docs/migrations/v0.25.0.md
+++ b/docs/migrations/v0.25.0.md
@@ -1,0 +1,49 @@
+# Migrating to v0.25.0
+
+Nothing to change. This note exists because the release alters how many database
+connections a process holds, which is a capacity question worth deciding
+deliberately rather than discovering.
+
+## What changed
+
+`postgrespresets.Default` now keeps up to **ten** idle connections per pool. It
+previously kept whatever `database/sql` defaults to, which is **two**.
+
+Two was never anyone's intended answer — it is the standard library's default
+leaking through a preset that otherwise makes opinionated choices. Past the second
+concurrent query, every call opened a fresh connection (a TCP round trip, a TLS
+handshake and a PostgreSQL authentication exchange) and discarded it on release.
+Nothing reported that: no error, no log, no failing test. It was a latency floor
+under every query in every service.
+
+## The capacity arithmetic, which is the reason to read this
+
+The limit is **per process**. What has to stay under the database's
+`max_connections` is the sum across every replica plus any job that connects:
+
+```
+replicas x idle_per_replica  +  jobs  <  max_connections
+```
+
+A stock PostgreSQL allows 100. Ten replicas of one service now sit at 100 idle
+connections on their own. If a deployment runs more replicas than that arithmetic
+allows, either raise `max_connections` or lower the pool.
+
+## Overriding it
+
+The field is on the config, so it is set where the config is built:
+
+```go
+config := postgrespresets.NewDefault(pgdriver.WithDSN(dsn))
+config.MaxIdleConns = 4   // or a negative value to keep none, as before
+```
+
+Zero means the default. A negative value keeps no idle connections, matching
+`database/sql`, and is the way back to the old behaviour if a deployment needs it.
+
+## What deliberately did not change
+
+The maximum number of **open** connections. That depends on how many replicas run
+against one database and how hard they are driven, which is a service's decision
+rather than a library's — services set it themselves, from configuration, when
+they build the pool.

--- a/postgres/presets/default.go
+++ b/postgres/presets/default.go
@@ -18,6 +18,22 @@ const (
 	// Schema names cannot be passed as query parameters, so the name is
 	// interpolated into the statement rather than bound.
 	CreateSchema = "CREATE SCHEMA IF NOT EXISTS %s;"
+
+	// MaxIdleConnsDefault is the number of idle connections a pool keeps when the
+	// caller expresses no preference.
+	//
+	// It exists because database/sql keeps two, and two is nobody's intended
+	// answer: past the second concurrent query every call opens a fresh
+	// connection — a TCP round trip, a TLS handshake and a PostgreSQL
+	// authentication exchange — then discards it on release. Nothing reports that.
+	// It is simply a latency floor under every query, in every service, that no
+	// error or log or test attributes to anything.
+	//
+	// Idle connections are cheap: a file descriptor here and a backend on the
+	// server. The handshake they save is not. Ten is deliberately modest — it must
+	// stay well under a stock max_connections of 100 once multiplied by however
+	// many replicas a service runs.
+	MaxIdleConnsDefault = 10
 )
 
 // Default is the standard postgres.Config implementation, backed by pgdriver.
@@ -25,6 +41,14 @@ const (
 // one per requested schema, all guarded by a single mutex.
 type Default struct {
 	options []pgdriver.Option
+
+	// MaxIdleConns overrides how many idle connections the pools keep. Zero means
+	// MaxIdleConnsDefault; a negative value keeps none, matching database/sql.
+	//
+	// The maximum number of OPEN connections is deliberately not here. That one
+	// depends on how many replicas a deployment runs against one database, which
+	// is a service's decision, not a library's.
+	MaxIdleConns int
 
 	// Cached connection to the primary database, opened on first use.
 	db *bun.DB
@@ -50,6 +74,7 @@ func (config *Default) DB(ctx context.Context) (*bun.DB, error) {
 	if config.db == nil {
 		sqldb := sql.OpenDB(pgdriver.NewConnector(config.options...))
 		db := bun.NewDB(sqldb, pgdialect.New(), bun.WithDiscardUnknownColumns())
+		db.SetMaxIdleConns(config.maxIdleConns())
 
 		err := postgres.Ping(ctx, db)
 		if err != nil {
@@ -96,6 +121,7 @@ func (config *Default) DBSchema(ctx context.Context, schema string, create bool)
 
 	sqldb := sql.OpenDB(pgdriver.NewConnector(options...))
 	db = bun.NewDB(sqldb, pgdialect.New(), bun.WithDiscardUnknownColumns())
+	db.SetMaxIdleConns(config.maxIdleConns())
 
 	err = postgres.Ping(ctx, db)
 	if err != nil {
@@ -115,4 +141,14 @@ func (config *Default) Options() []pgdriver.Option {
 	defer config.mu.RUnlock()
 
 	return append([]pgdriver.Option{}, config.options...)
+}
+
+// maxIdleConns resolves the configured override against the default. Callers hold
+// the mutex.
+func (config *Default) maxIdleConns() int {
+	if config.MaxIdleConns == 0 {
+		return MaxIdleConnsDefault
+	}
+
+	return config.MaxIdleConns
 }

--- a/postgres/presets/default_test.go
+++ b/postgres/presets/default_test.go
@@ -1,0 +1,112 @@
+package postgrespresets_test
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun/driver/pgdriver"
+
+	postgrespresets "github.com/a-novel-kit/golib/postgres/presets"
+)
+
+// concurrentQueries is how many statements the tests run at once. It sits above
+// database/sql's own idle default of two and below the preset's, so the number of
+// connections left idle afterwards distinguishes the two.
+const concurrentQueries = 5
+
+func testConfig(t *testing.T) *postgrespresets.Default {
+	t.Helper()
+
+	dsn := os.Getenv("POSTGRES_DSN")
+	require.NotEmpty(t, dsn,
+		"POSTGRES_DSN must point at a throwaway database — this package opens real connections")
+
+	return postgrespresets.NewDefault(pgdriver.WithDSN(dsn))
+}
+
+// holdOpen runs concurrentQueries statements that overlap in time, forcing the pool
+// to open that many connections, and returns once every one has been released back
+// to it.
+func holdOpen(ctx context.Context, t *testing.T, config *postgrespresets.Default) {
+	t.Helper()
+
+	db, err := config.DB(ctx)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	for range concurrentQueries {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			// A sleep rather than a trivial select: the statements have to overlap, and
+			// a fast query would be served by one connection handed round.
+			_, queryErr := db.NewRaw("SELECT pg_sleep(0.2);").Exec(ctx)
+			// assert, not require: require calls FailNow, which only works on the
+			// goroutine running the test.
+			assert.NoError(t, queryErr)
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestDefaultKeepsIdleConnections is the regression test for the pool's idle
+// default. It fails against a preset that leaves database/sql's own default in
+// place, because only two of the five connections would survive being released —
+// and the other three would be reopened, handshake and all, by the next caller.
+func TestDefaultKeepsIdleConnections(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t)
+
+	ctx := t.Context()
+	holdOpen(ctx, t, config)
+
+	db, err := config.DB(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, concurrentQueries, db.Stats().Idle,
+		"every released connection should have been kept, not closed and reopened later")
+}
+
+// TestDefaultHonoursTheOverride covers the escape hatch: a deployment that wants a
+// different number gets it, and the default only applies when none was expressed.
+func TestDefaultHonoursTheOverride(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t)
+	config.MaxIdleConns = 1
+
+	ctx := t.Context()
+	holdOpen(ctx, t, config)
+
+	db, err := config.DB(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, db.Stats().Idle)
+}
+
+// TestDefaultNegativeOverrideKeepsNone pins the one value that is not "unset": a
+// negative override means keep nothing, matching database/sql, rather than falling
+// back to the default.
+func TestDefaultNegativeOverrideKeepsNone(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t)
+	config.MaxIdleConns = -1
+
+	ctx := t.Context()
+	holdOpen(ctx, t, config)
+
+	db, err := config.DB(ctx)
+	require.NoError(t, err)
+
+	require.Zero(t, db.Stats().Idle)
+}


### PR DESCRIPTION
## Summary

Both pool limits move onto `postgrespresets.Default`, where a service states them declaratively.

- **`MaxIdleConns` gets a default of ten.** It previously inherited `database/sql`'s **two**, which is nobody's intended answer: past the second concurrent query every call opened a fresh connection — a TCP round trip, a TLS handshake and a PostgreSQL authentication exchange — and discarded it on release. No error, no log, no failing test. A latency floor under every query in every service.
- **`MaxOpenConns` gets a field and no default.** Zero still means unlimited, exactly as today. How many connections a deployment may hold depends on how many replicas share one database, which a library cannot know.

Ships `docs/migrations/v0.25.0.md`.

Closes #373

## Why the limits belong on the config, not the pool

The obvious alternative is for each service to reach into the pool after opening it:

```go
pool := lo.Must(cfg.Postgres.DB(ctx))
pool.SetMaxOpenConns(n)
```

That works only if it runs before anything else asks for a connection, because the handle is cached — and nothing enforces that ordering. When it is missed the limits apply to nothing, no error is raised, and the code reads as correct. It is the same shape as the defect this milestone is named for.

On the config there is no ordering to get wrong: the pool is bounded as it is opened, on both the primary and per-schema paths.

## What to scrutinise

**All five tests were verified to fail against the previous behaviour**, and the clearest names it outright — with the idle default removed, `TestDefaultNegativeOverrideKeepsNone` reports *"Should be zero, but was 2"*. That is `database/sql`'s default, observed directly.

They are behavioural rather than a read-back of the setter: `sql.DB` exposes no getter for the idle limit, so the tests run overlapping `pg_sleep` statements to force the pool open and count what survives in `Stats()`. The open-limit test additionally asserts the cap holds *under contention*, not merely that it reports itself. These are the first tests in `postgres/presets` — possible only because #374 added the database service container.

**Zero means unset; negative means keep none.** A Go zero value cannot express "the caller asked for none", so the way back to the old behaviour has to be expressible, and it is tested.

**Ten is a capacity decision.** The limit is per process: `replicas × idle + jobs < max_connections`, against a stock 100. Ten replicas of one service reach 100 on their own. The migration note carries that arithmetic rather than burying it in a doc comment.

## Consumers

The three services that need bounded pools depend on this releasing first — a-novel/service-template#400, a-novel/service-authentication#1116, a-novel/service-json-keys#826. They pin the released tag and set both fields where they build their config.

## Breaking changes

None. Two new fields whose zero values preserve "unconfigured", and one default that changes resource usage rather than API.

## Test plan

- [x] `go test ./...` passes against a real Postgres 18.4
- [x] `pnpm lint:go`, `pnpm lint:prettier` clean
- [x] Every test confirmed failing against the pre-fix behaviour
- [ ] CI green