### PR TITLE
docs: trim and refocus code comments

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -25,8 +25,8 @@ func LoadEnv[T any](value string, fallback T, parser func(string) (T, error)) T 
 	return parsedValue
 }
 
-// SliceParser is a parsing function for LoadEnv, that returns a slice of values of type T.
-// The parser accepts a sub-parser to define the type of T.
+// SliceParser builds a [LoadEnv] parser for a comma-separated list, delegating each
+// element to parser.
 func SliceParser[T any](parser func(string) (T, error)) func(string) ([]T, error) {
 	return func(value string) ([]T, error) {
 		// The literal "[]" selects an empty result, overriding any fallback.
@@ -62,7 +62,7 @@ func SliceParser[T any](parser func(string) (T, error)) func(string) ([]T, error
 	}
 }
 
-// StringParser is a parsing function for LoadEnv, that returns the string content of the variable, as-is.
+// StringParser returns the raw value unchanged, for [LoadEnv].
 func StringParser(value string) (string, error) {
 	return value, nil
 }
@@ -85,115 +85,98 @@ func EnumParser[T comparable](parser func(string) (T, error), allow ...T) func(s
 	}
 }
 
-// Int64Parser is a parsing function for LoadEnv, that returns the int64 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseInt.
+// Int64Parser parses an int64 for [LoadEnv], accepting the formats of strconv.ParseInt.
 func Int64Parser(value string) (int64, error) {
 	return strconv.ParseInt(value, 0, 64)
 }
 
-// Int32Parser is a parsing function for LoadEnv, that returns the int32 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseInt.
+// Int32Parser parses an int32 for [LoadEnv], accepting the formats of strconv.ParseInt.
 func Int32Parser(value string) (int32, error) {
 	parsedValue, err := strconv.ParseInt(value, 0, 32)
 
 	return int32(parsedValue), err
 }
 
-// Int16Parser is a parsing function for LoadEnv, that returns the int16 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseInt.
+// Int16Parser parses an int16 for [LoadEnv], accepting the formats of strconv.ParseInt.
 func Int16Parser(value string) (int16, error) {
 	parsedValue, err := strconv.ParseInt(value, 0, 16)
 
 	return int16(parsedValue), err
 }
 
-// Int8Parser is a parsing function for LoadEnv, that returns the int8 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseInt.
+// Int8Parser parses an int8 for [LoadEnv], accepting the formats of strconv.ParseInt.
 func Int8Parser(value string) (int8, error) {
 	parsedValue, err := strconv.ParseInt(value, 0, 8)
 
 	return int8(parsedValue), err
 }
 
-// IntParser is a parsing function for LoadEnv, that returns the int representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.Atoi.
+// IntParser parses an int for [LoadEnv], accepting the formats of strconv.Atoi.
 func IntParser(value string) (int, error) {
 	return strconv.Atoi(value)
 }
 
-// Uint64Parser is a parsing function for LoadEnv, that returns the uint64 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseUint.
+// Uint64Parser parses a uint64 for [LoadEnv], accepting the formats of strconv.ParseUint.
 func Uint64Parser(value string) (uint64, error) {
 	return strconv.ParseUint(value, 0, 64)
 }
 
-// Uint32Parser is a parsing function for LoadEnv, that returns the uint32 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseUint.
+// Uint32Parser parses a uint32 for [LoadEnv], accepting the formats of strconv.ParseUint.
 func Uint32Parser(value string) (uint32, error) {
 	parsedValue, err := strconv.ParseUint(value, 0, 32)
 
 	return uint32(parsedValue), err
 }
 
-// Uint16Parser is a parsing function for LoadEnv, that returns the uint16 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseUint.
+// Uint16Parser parses a uint16 for [LoadEnv], accepting the formats of strconv.ParseUint.
 func Uint16Parser(value string) (uint16, error) {
 	parsedValue, err := strconv.ParseUint(value, 0, 16)
 
 	return uint16(parsedValue), err
 }
 
-// Uint8Parser is a parsing function for LoadEnv, that returns the uint8 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseUint.
+// Uint8Parser parses a uint8 for [LoadEnv], accepting the formats of strconv.ParseUint.
 func Uint8Parser(value string) (uint8, error) {
 	parsedValue, err := strconv.ParseUint(value, 0, 8)
 
 	return uint8(parsedValue), err
 }
 
-// UintParser is a parsing function for LoadEnv, that returns the uint representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseUint.
+// UintParser parses a uint for [LoadEnv], accepting the formats of strconv.ParseUint.
 func UintParser(value string) (uint, error) {
 	parsedValue, err := strconv.ParseUint(value, 0, 0)
 
 	return uint(parsedValue), err
 }
 
-// BoolParser is a parsing function for LoadEnv, that returns the boolean equivalent of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseBool.
+// BoolParser parses a bool for [LoadEnv], accepting the formats of strconv.ParseBool.
 func BoolParser(value string) (bool, error) {
 	return strconv.ParseBool(value)
 }
 
-// Float64Parser is a parsing function for LoadEnv, that returns the float64 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseFloat.
+// Float64Parser parses a float64 for [LoadEnv], accepting the formats of strconv.ParseFloat.
 func Float64Parser(value string) (float64, error) {
 	return strconv.ParseFloat(value, 64)
 }
 
-// Float32Parser is a parsing function for LoadEnv, that returns the float32 representation of the variable.
-// For more information about supported value, refer to the documentation of strconv.ParseFloat.
+// Float32Parser parses a float32 for [LoadEnv], accepting the formats of strconv.ParseFloat.
 func Float32Parser(value string) (float32, error) {
 	parsedValue, err := strconv.ParseFloat(value, 32)
 
 	return float32(parsedValue), err
 }
 
-// DurationParser is a parsing function for LoadEnv, that returns the time.Duration representation of the variable.
-// For more information about supported value, refer to the documentation of time.ParseDuration.
+// DurationParser parses a time.Duration for [LoadEnv], accepting the formats of time.ParseDuration.
 func DurationParser(value string) (time.Duration, error) {
 	return time.ParseDuration(value)
 }
 
-// TimeParser is a parsing function for LoadEnv, that returns the time.Time representation of the variable.
-// The parser expects the time to be in time.RFC3339 format. For more information about supported value,
-// refer to the documentation of time.Parse.
+// TimeParser parses a time.Time for [LoadEnv], expecting the time.RFC3339 format.
 func TimeParser(value string) (time.Time, error) {
 	return time.Parse(time.RFC3339, value)
 }
 
-// JSONMapParser is a parsing function for LoadEnv, that returns the map[string]any representation of the variable.
-// The parser expects the value to be a valid JSON object.
+// JSONMapParser parses a JSON object into a map[string]any, for [LoadEnv].
 func JSONMapParser(value string) (map[string]any, error) {
 	var parsedValue map[string]any
 
@@ -205,8 +188,7 @@ func JSONMapParser(value string) (map[string]any, error) {
 	return parsedValue, nil
 }
 
-// JSONSliceParser is a parsing function for LoadEnv, that returns the []any representation of the variable.
-// The parser expects the value to be a valid JSON array.
+// JSONSliceParser parses a JSON array into a []any, for [LoadEnv].
 func JSONSliceParser(value string) ([]any, error) {
 	var parsedValue []any
 

--- a/grpcf/any.go
+++ b/grpcf/any.go
@@ -10,10 +10,8 @@ import (
 
 // MarshalJSONAsAny serializes an arbitrary Go value to JSON and packs the
 // resulting bytes into a google.protobuf.Any whose contained message type is
-// google.protobuf.BytesValue. Use it only when an RPC field is typed as Any
-// and you actually want to carry an opaque JSON payload — Any is normally
-// reserved for genuine protobuf messages, so this is a deliberate escape
-// hatch, not the default way to transit data.
+// google.protobuf.BytesValue. Use it where an RPC field typed as Any must carry
+// an opaque JSON payload; Any otherwise holds genuine protobuf messages.
 //
 // The inverse is [UnmarshalJSONFromAny].
 func MarshalJSONAsAny(v any) (*anypb.Any, error) {

--- a/grpcf/echo.go
+++ b/grpcf/echo.go
@@ -28,8 +28,7 @@ func (handler *echo) UnaryEcho(context.Context, *golibproto.UnaryEchoRequest) (*
 // shutdown.
 //
 // A non-positive healthPing degrades to a tight toggle loop that still
-// honors ctx cancellation. time.NewTicker would panic on a zero or negative
-// duration, so the wait is built around time.After instead.
+// honors ctx cancellation.
 func SetEchoServersContext(ctx context.Context, server *grpc.Server, healthPing time.Duration) {
 	healthcheck := health.NewServer()
 	healthpb.RegisterHealthServer(server, healthcheck)

--- a/logging/presets/http.local.go
+++ b/logging/presets/http.local.go
@@ -66,8 +66,8 @@ func (logger *HTTPLocal) Logger() func(http.Handler) http.Handler {
 				message += lstyle.Render("\n\t" + strings.ReplaceAll(body, "\n", "\n\t"))
 			}
 
-			// Dumping the raw response body would leak sensitive data in
-			// production, but this preset only ever runs in local development.
+			// This preset only ever runs in local development, where dumping the
+			// raw response body is safe.
 			_, _ = fmt.Fprint(logger.BaseLogger.Out, strings.TrimSpace(message)+"\n")
 		})
 	}

--- a/otel/presets/sentry.go
+++ b/otel/presets/sentry.go
@@ -62,7 +62,6 @@ func (config *Sentry) Init() error {
 			}
 
 			if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
-				// Add IP Address to user information.
 				event.User.IPAddress = req.RemoteAddr
 			}
 
@@ -79,8 +78,8 @@ func (config *Sentry) GetPropagators() (propagation.TextMapPropagator, error) {
 }
 
 func (config *Sentry) GetTraceProvider() (trace.TracerProvider, error) {
-	// sentry-go v0.47 dropped the span processor in favour of an OTLP span exporter.
-	// The batch processor buffers spans and is drained by Flush -> tp.Shutdown.
+	// Spans reach Sentry through an OTLP exporter. The batch processor buffers them
+	// and is drained by Flush -> tp.Shutdown.
 	exporter, err := sentryotlp.NewTraceExporter(context.Background(), config.DSN)
 	if err != nil {
 		return nil, err

--- a/postgres/migrator.go
+++ b/postgres/migrator.go
@@ -13,8 +13,8 @@ import (
 )
 
 // ErrNoDbInContext is returned by RunMigrationsContext when the context carries
-// a bun.IDB that is not a full *bun.DB. Migrations need a database handle, not a
-// transaction; [ErrNoIDBInContext] covers the case of no connection at all.
+// a bun.IDB that is not a full *bun.DB, which migrations require.
+// [ErrNoIDBInContext] covers the case of no connection at all.
 var ErrNoDbInContext = errors.New("context does not contain a bun.DB")
 
 // RunMigrations runs all the migrations found in the provided filesystem.

--- a/postgres/passthrough.go
+++ b/postgres/passthrough.go
@@ -7,22 +7,19 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// PassthroughTx is an extension of bun.Tx that prevents sub contexts from creating new sub-transactions.
+// PassthroughTx extends bun.Tx so that a nested transaction call resolves to the
+// same transaction.
 //
-// Because postgresql does not support nested transactions, bun will create savepoints instead. Unlike
-// top-level transactions, savepoints don't support parallelism (as they are part of the same query).
-//
-// For testing, where the whole application is wrapped in a transaction, this can cause issues where
-// multiple parallel calls to a method will attempt concurrent write on the same transaction.
-//
-// To get around it, this package provides an alternative bun.IDB implementation, that does not create
-// new transactions.
+// PostgreSQL has no nested transactions, so bun opens a savepoint instead. A
+// savepoint belongs to its parent's query stream and cannot serve parallel
+// callers, which breaks a test suite that wraps the whole application in one
+// transaction and then calls a method from several goroutines.
 type PassthroughTx struct {
 	bun.Tx
 }
 
 // NewPassthroughTx wraps tx so that nested transaction calls resolve to tx
-// itself rather than opening savepoints.
+// itself.
 func NewPassthroughTx(tx bun.Tx) *PassthroughTx {
 	return &PassthroughTx{Tx: tx}
 }

--- a/postgres/ping.go
+++ b/postgres/ping.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
+	// PingTimeout bounds how long Ping keeps retrying before giving up.
 	PingTimeout = 10 * time.Second
-	// PingRetryInterval is the wait between failed ping attempts. Without it,
-	// Ping would tight-loop reconnects on an unreachable database for the
-	// duration of PingTimeout.
+	// PingRetryInterval is the wait between failed ping attempts, keeping Ping
+	// from tight-looping reconnects on an unreachable database.
 	PingRetryInterval = 100 * time.Millisecond
 )
 

--- a/postgres/presets/default.go
+++ b/postgres/presets/default.go
@@ -15,24 +15,19 @@ import (
 
 const (
 	// CreateSchema is the format string for the statement that creates a schema.
-	// Schema names cannot be passed as query parameters, so the name is
-	// interpolated into the statement rather than bound.
+	// Schema names cannot be bound as query parameters, so the name is
+	// interpolated into the statement.
 	CreateSchema = "CREATE SCHEMA IF NOT EXISTS %s;"
 
 	// MaxIdleConnsDefault is the number of idle connections a pool keeps when the
 	// caller expresses no preference.
 	//
-	// It exists because database/sql keeps two, and two is nobody's intended
-	// answer: past the second concurrent query every call opens a fresh
-	// connection — a TCP round trip, a TLS handshake and a PostgreSQL
-	// authentication exchange — then discards it on release. Nothing reports that.
-	// It is simply a latency floor under every query, in every service, that no
-	// error or log or test attributes to anything.
-	//
-	// Idle connections are cheap: a file descriptor here and a backend on the
-	// server. The handshake they save is not. Ten is deliberately modest — it must
-	// stay well under a stock max_connections of 100 once multiplied by however
-	// many replicas a service runs.
+	// database/sql keeps two, so past the second concurrent query every call opens
+	// a fresh connection — a TCP round trip, a TLS handshake and a PostgreSQL
+	// authentication exchange — and discards it on release, putting a silent
+	// latency floor under every query. Idle connections cost a file descriptor
+	// here and a backend on the server; ten stays well under a stock
+	// max_connections of 100 once multiplied by a service's replica count.
 	MaxIdleConnsDefault = 10
 )
 
@@ -44,10 +39,6 @@ type Default struct {
 
 	// MaxIdleConns overrides how many idle connections the pools keep. Zero means
 	// MaxIdleConnsDefault; a negative value keeps none, matching database/sql.
-	//
-	// The maximum number of OPEN connections is deliberately not here. That one
-	// depends on how many replicas a deployment runs against one database, which
-	// is a service's decision, not a library's.
 	MaxIdleConns int
 
 	// Cached connection to the primary database, opened on first use.
@@ -87,11 +78,9 @@ func (config *Default) DB(ctx context.Context) (*bun.DB, error) {
 	return config.db, nil
 }
 
-// DBSchema returns a database connection for the specified schema. It smartly caches and reuses connections for
-// any given schema name.
-//
-// If the `create` parameter is true, and no connection exists for the specified schema, it will create the schema
-// in the database before returning the connection.
+// DBSchema returns a database connection scoped to the named schema, caching one
+// connection per schema name. When create is true and the schema has no cached
+// connection yet, the schema is created before the connection is returned.
 func (config *Default) DBSchema(ctx context.Context, schema string, create bool) (*bun.DB, error) {
 	db, err := config.DB(ctx)
 	if err != nil {

--- a/postgres/presets/default_test.go
+++ b/postgres/presets/default_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 // concurrentQueries is how many statements the tests run at once. It sits above
-// database/sql's own idle default of two and below the preset's, so the number of
-// connections left idle afterwards distinguishes the two.
+// database/sql's own idle default of two and below the preset's, so the number
+// of connections left idle afterwards tells the two apart.
 const concurrentQueries = 5
 
 func testConfig(t *testing.T) *postgrespresets.Default {
@@ -45,11 +45,11 @@ func holdOpen(ctx context.Context, t *testing.T, config *postgrespresets.Default
 		go func() {
 			defer wg.Done()
 
-			// A sleep rather than a trivial select: the statements have to overlap, and
-			// a fast query would be served by one connection handed round.
+			// The statements have to overlap. pg_sleep holds each connection long enough
+			// for the pool to open a second.
 			_, queryErr := db.NewRaw("SELECT pg_sleep(0.2);").Exec(ctx)
-			// assert, not require: require calls FailNow, which only works on the
-			// goroutine running the test.
+			// require calls FailNow, which only works on the goroutine running the
+			// test.
 			assert.NoError(t, queryErr)
 		}()
 	}
@@ -57,10 +57,8 @@ func holdOpen(ctx context.Context, t *testing.T, config *postgrespresets.Default
 	wg.Wait()
 }
 
-// TestDefaultKeepsIdleConnections is the regression test for the pool's idle
-// default. It fails against a preset that leaves database/sql's own default in
-// place, because only two of the five connections would survive being released —
-// and the other three would be reopened, handshake and all, by the next caller.
+// TestDefaultKeepsIdleConnections pins the pool's idle default. All five connections
+// survive being released. The next caller reuses them without a fresh handshake.
 func TestDefaultKeepsIdleConnections(t *testing.T) {
 	t.Parallel()
 
@@ -76,8 +74,8 @@ func TestDefaultKeepsIdleConnections(t *testing.T) {
 		"every released connection should have been kept, not closed and reopened later")
 }
 
-// TestDefaultHonoursTheOverride covers the escape hatch: a deployment that wants a
-// different number gets it, and the default only applies when none was expressed.
+// TestDefaultHonoursTheOverride covers the escape hatch: a deployment that sets
+// its own number gets it, and the default applies only when none was expressed.
 func TestDefaultHonoursTheOverride(t *testing.T) {
 	t.Parallel()
 
@@ -94,8 +92,7 @@ func TestDefaultHonoursTheOverride(t *testing.T) {
 }
 
 // TestDefaultNegativeOverrideKeepsNone pins the one value that is not "unset": a
-// negative override means keep nothing, matching database/sql, rather than falling
-// back to the default.
+// negative override keeps nothing, matching database/sql.
 func TestDefaultNegativeOverrideKeepsNone(t *testing.T) {
 	t.Parallel()
 

--- a/postgres/test.go
+++ b/postgres/test.go
@@ -39,11 +39,13 @@ func NewContextTest(ctx context.Context, config Config) (context.Context, error)
 	return context.WithValue(ctx, ContextKey{}, db), nil
 }
 
-// RunIsolatedTransactionalTest runs test in a temporary throwaway schema. This allows for operations that cannot
-// be performed concurrently in a transactional context, such as refreshing materialized views.
+// RunIsolatedTransactionalTest runs callback in a throwaway schema, which admits
+// operations a transaction cannot host concurrently, such as refreshing a
+// materialized view.
 //
-// This method uses a separate schema, rather than a new database, so existing extensions are still available. It
-// still requires to rerun the whole migration process, so unless needed, RunTransactionalTest should be preferred.
+// The schema lives in the existing database, so its extensions remain available.
+// Each call reruns the whole migration set, which makes RunTransactionalTest the
+// cheaper default.
 func RunIsolatedTransactionalTest(t *testing.T, config Config, migrations fs.FS, callback TransactionalTestFunc) {
 	t.Helper()
 
@@ -59,9 +61,9 @@ func RunIsolatedTransactionalTest(t *testing.T, config Config, migrations fs.FS,
 	callback(ctx, t)
 }
 
-// RunTransactionalTest creates a special transactional context for testing. This context uses the PassthroughTx
-// implementation, that allows for concurrent tests with the same database connection. It discards sub-transactions
-// to prevent deadlocks.
+// RunTransactionalTest runs callback inside a transaction that is rolled back on
+// cleanup. The context carries a PassthroughTx, which discards sub-transactions
+// so concurrent calls sharing the connection cannot deadlock.
 func RunTransactionalTest(t *testing.T, config Config, callback TransactionalTestFunc) {
 	t.Helper()
 
@@ -85,9 +87,8 @@ func RunTransactionalTest(t *testing.T, config Config, callback TransactionalTes
 const (
 	// dbTestTemplatePrefix names the migrated template database that every
 	// per-test database is cloned from. Its suffix is a content hash of the
-	// migration set (see dbTestTemplateName), so changing a migration yields a
-	// brand-new template name automatically and a stale template from older
-	// code can never serve an outdated schema to a newer test binary.
+	// migration set (see dbTestTemplateName), so a migration change yields a new
+	// template name and no test binary can be served an outdated schema.
 	dbTestTemplatePrefix = "gotpl_"
 
 	// dbTestInstancePrefix names a throwaway per-test database. Exactly one is
@@ -95,17 +96,16 @@ const (
 	dbTestInstancePrefix = "gotest_"
 
 	// dbTestMaintenanceDatabase is the database the maintenance connection
-	// targets to issue CREATE DATABASE / DROP DATABASE. Neither statement can
-	// run while connected to the database being created, nor (for CREATE …
-	// TEMPLATE) while any session is connected to the template source, so the
-	// maintenance pool deliberately points at an unrelated database.
+	// targets to issue CREATE DATABASE / DROP DATABASE. Neither statement can run
+	// from the database being created, and CREATE … TEMPLATE needs the template
+	// source free of sessions, so the maintenance pool points at an unrelated
+	// database.
 	dbTestMaintenanceDatabase = "postgres"
 
-	// dbTestCreateAttempts bounds the retry of CREATE DATABASE … TEMPLATE.
-	// Cloning a template only fails transiently — a previous clone's
-	// connections taking a moment to drain shows up as SQLSTATE 55006
-	// (object_in_use); a short bounded retry absorbs that without masking a
-	// real configuration error, which fails every attempt identically.
+	// dbTestCreateAttempts bounds the retry of CREATE DATABASE … TEMPLATE. A
+	// previous clone's connections taking a moment to drain surfaces as SQLSTATE
+	// 55006 (object_in_use), which a short bounded retry absorbs; a real
+	// configuration error fails every attempt alike.
 	dbTestCreateAttempts = 5
 	// dbTestCreateBackoff is the wait between CREATE DATABASE … TEMPLATE
 	// attempts.
@@ -114,48 +114,39 @@ const (
 
 // dbTestOptionsConfig is the capability RunDBTest needs on top of the Config
 // interface: read access to the raw driver options, so it can derive sibling
-// connectors that target a different database (the maintenance database, the
-// template, and the per-test clone) than the one the preset was built for.
-// postgrespresets.Default satisfies this; a Config that does not is rejected
-// with a clear failure rather than a panic deep in the driver.
+// connectors targeting another database in the same cluster, such as the
+// per-test clone. postgrespresets.Default satisfies it.
 type dbTestOptionsConfig interface {
 	Options() []pgdriver.Option
 }
 
 // dbTestTemplated guards one-time template creation within a process. The first
 // RunDBTest call for a given (migrations, target-cluster) pair runs the
-// migrations (every other call blocks on dbTestMu meanwhile); subsequent calls
-// find it flagged and return immediately, so only the first test pays the
-// migration cost and the rest clone in parallel. The key includes the resolved
-// connection identity (see dbTestConnKey), not just the migration hash, so the
-// same migrations applied against two different clusters/roles in one process
-// do not alias onto a template that exists only in the first cluster.
+// migrations while every other call blocks on dbTestMu, so only the first test
+// pays the migration cost and the rest clone in parallel. The key includes the
+// resolved connection identity (see dbTestConnKey), so the same migrations
+// applied against two clusters in one process do not alias onto a template that
+// exists in only one of them.
 //
-// Cross-process safety (several `go test` package binaries sharing one
-// Postgres) is handled separately by the Postgres advisory lock in
-// dbTestCreateTemplate; this map only deduplicates work inside a single binary.
-// A failed creation is intentionally not recorded, so a transient failure is
-// retried by the next test rather than poisoning the whole package run.
+// Cross-process safety comes from the Postgres advisory lock in
+// dbTestCreateTemplate; this map deduplicates work inside a single binary. A
+// failed creation is not recorded, so the next test retries it.
 var (
 	dbTestMu        sync.Mutex
 	dbTestTemplated = map[string]bool{}
 
 	// dbTestCloneMu serializes CREATE DATABASE … TEMPLATE within a process.
-	// PostgreSQL serializes CREATE DATABASE globally on the server anyway, so
-	// firing N parallel clones only produces N contending statements and a
-	// retry storm; taking them one at a time client-side matches what the
-	// server does regardless and removes the contention entirely. The bounded
-	// retry in dbTestCreateInstance then only has to absorb *cross-process*
-	// contention, not in-process self-contention.
+	// PostgreSQL serializes CREATE DATABASE globally, so parallel clones only
+	// produce contending statements and a retry storm. Taking them one at a time
+	// leaves the bounded retry in dbTestCreateInstance to absorb cross-process
+	// contention alone.
 	dbTestCloneMu sync.Mutex
 )
 
 // RunDBTest runs callback against its own freshly created PostgreSQL database,
-// cloned from a migrated template via `CREATE DATABASE … TEMPLATE`. Unlike
-// RunTransactionalTest (shared schema, rolled-back transaction — correct only
-// when tests run serially) every RunDBTest call is physically isolated, so the
-// caller may freely mark the test and its sub-tests t.Parallel() even when they
-// reuse the same fixture keys.
+// cloned from a migrated template via `CREATE DATABASE … TEMPLATE`. Every call
+// is physically isolated, so the caller may mark the test and its sub-tests
+// t.Parallel() even when they reuse the same fixture keys.
 //
 // The cost model is "migrate once, clone many": the migration set is applied a
 // single time into a template database whose name is a hash of the migrations,
@@ -186,14 +177,13 @@ func RunDBTest(t *testing.T, config Config, migrations fs.FS, callback Transacti
 	err = dbTestCreateInstance(t.Context(), maintenance, instance, template)
 	require.NoError(t, err)
 
-	// Register the drop the instant the database exists — before the
-	// maintenance pool is closed — so a Close error (which fails the test via
-	// the require below) cannot strand the per-test database. It runs last
-	// (t.Cleanup is LIFO): the per-test pool opened further down is closed
-	// first, then the database is dropped.
+	// Register the drop the instant the database exists, before the maintenance
+	// pool is closed, so a Close error (which fails the test via the require
+	// below) cannot strand the per-test database. t.Cleanup is LIFO, so the
+	// per-test pool opened further down is closed first, then the database is
+	// dropped.
 	t.Cleanup(func() {
-		// t.Context() is already cancelled by the time cleanups run, so use a
-		// fresh background context for teardown.
+		// t.Context() is already canceled by the time cleanups run.
 		ctx := context.Background()
 
 		cleanup, cleanupErr := dbTestOpen(ctx, options, dbTestMaintenanceDatabase)
@@ -228,9 +218,9 @@ func dbTestEnsureTemplate(ctx context.Context, options []pgdriver.Option, migrat
 		return "", err
 	}
 
-	// Key by template name *and* resolved connection identity: the same
-	// migrations against a different cluster/role is a different template that
-	// this process has not necessarily created yet.
+	// Key by template name and resolved connection identity: the same migrations
+	// against a different cluster or role is a different template, which this
+	// process has not necessarily created yet.
 	cacheKey := name + "\x00" + dbTestConnKey(options)
 
 	dbTestMu.Lock()
@@ -250,10 +240,10 @@ func dbTestEnsureTemplate(ctx context.Context, options []pgdriver.Option, migrat
 	return name, nil
 }
 
-// dbTestConnKey returns a stable identifier for the Postgres target that
-// options resolve to (address, user, base database). It keys the in-process
-// template cache so the same migrations applied against two different clusters
-// in one process are not aliased onto a single cache entry.
+// dbTestConnKey returns a stable identifier for the Postgres target that options
+// resolve to (address, user, base database). It keys the in-process template
+// cache, so the same migrations applied against two clusters in one process get
+// two cache entries.
 func dbTestConnKey(options []pgdriver.Option) string {
 	config := pgdriver.NewConnector(options...).Config()
 
@@ -267,9 +257,8 @@ func dbTestConnKey(options []pgdriver.Option) string {
 // scoped to the maintenance connection (closing the connection releases it even
 // if the explicit unlock is skipped on an error path).
 //
-// Crucially, the migration pool is fully closed before returning: a database
-// can only serve as a CREATE … TEMPLATE source while no session is connected to
-// it, so any lingering connection here would break every clone.
+// The migration pool is fully closed before returning. A database can only serve as a
+// CREATE … TEMPLATE source while no session is connected to it.
 func dbTestCreateTemplate(
 	ctx context.Context, options []pgdriver.Option, name string, migrations fs.FS,
 ) error {
@@ -300,9 +289,9 @@ func dbTestCreateTemplate(
 		return fmt.Errorf("probe template database: %w", err)
 	}
 
-	// A matching name means a previous run (this binary or another) already
-	// migrated it; the content hash in the name guarantees the schema matches
-	// the current migration set, so it is safe to reuse as-is.
+	// A matching name means a previous run already migrated it, and the content
+	// hash in the name guarantees the schema matches the current migration set,
+	// so it is safe to reuse as-is.
 	if exists {
 		return nil
 	}
@@ -312,10 +301,10 @@ func dbTestCreateTemplate(
 		return fmt.Errorf("create template database: %w", err)
 	}
 
-	// The template database now exists but is empty/unmigrated. Any failure
-	// from here must drop it: otherwise the existence probe in a later call
-	// (this binary or another) would adopt the empty/partial database as a
-	// valid template and run every test against a broken schema.
+	// The template database now exists but is unmigrated, so any failure from
+	// here must drop it; otherwise the existence probe in a later call adopts the
+	// partial database as a valid template and every test runs against a broken
+	// schema.
 	templateDB, err := dbTestOpen(ctx, options, name)
 	if err != nil {
 		_ = dbTestDropDatabase(ctx, maintenance, name)
@@ -331,9 +320,9 @@ func dbTestCreateTemplate(
 		return fmt.Errorf("migrate template database: %w", err)
 	}
 
-	// Must succeed: an open connection to the template makes every subsequent
-	// CREATE … TEMPLATE fail with "source database is being accessed". A
-	// half-open template is unusable as a clone source, so drop it too.
+	// An open connection to the template makes every subsequent CREATE … TEMPLATE
+	// fail with "source database is being accessed", so a template whose
+	// connection cannot be closed is dropped.
 	err = templateDB.Close()
 	if err != nil {
 		_ = dbTestDropDatabase(ctx, maintenance, name)
@@ -367,9 +356,6 @@ func dbTestCreateInstance(ctx context.Context, maintenance *bun.DB, instance, te
 		dbTestQuoteIdent(instance), dbTestQuoteIdent(template),
 	)
 
-	// Serialize clones in-process: PostgreSQL serializes CREATE DATABASE
-	// globally anyway, so taking them one at a time here matches the server
-	// and leaves the retry below to handle only cross-process contention.
 	dbTestCloneMu.Lock()
 	defer dbTestCloneMu.Unlock()
 
@@ -394,10 +380,9 @@ func dbTestCreateInstance(ctx context.Context, maintenance *bun.DB, instance, te
 }
 
 // dbTestOpen opens a bun.DB for a single named database, derived from the
-// preset's options by overriding only the database name. The override is a
-// trailing pgdriver.WithDatabase: pgdriver applies options in order, so it wins
-// over whatever database the preset's own options (a DSN, discrete options, …)
-// selected, without this code having to parse them.
+// preset's options by overriding only the database name. pgdriver applies
+// options in order, so a trailing pgdriver.WithDatabase wins over whatever
+// database the preset's own options selected, with no need to parse them.
 func dbTestOpen(ctx context.Context, options []pgdriver.Option, database string) (*bun.DB, error) {
 	options = append(append([]pgdriver.Option{}, options...), pgdriver.WithDatabase(database))
 
@@ -437,23 +422,19 @@ func dbTestTemplateName(migrations fs.FS) (string, error) {
 		fileDigest := sha256.New()
 
 		_, err = io.Copy(fileDigest, file)
-		// Close immediately rather than via defer: defer here would hold every
-		// migration file open until WalkDir finished, risking fd exhaustion on
-		// large OS-backed migration sets.
+		// Closing here keeps one migration file open at a time, however large the
+		// migration set.
 		_ = file.Close()
 
 		if err != nil {
 			return err
 		}
 
-		// Frame each entry unambiguously: a length-prefixed path followed by a
-		// fixed-size (32-byte) content digest. Writing path and content
-		// back-to-back without framing would let a path/content boundary move
-		// (e.g. file "ab"/content "c" vs file "a"/content "bc") produce an
-		// identical byte stream for distinct migration sets, defeating the
-		// "a migration change always yields a fresh template" guarantee.
-		// fs.WalkDir visits entries in lexical order, so the digest is stable
-		// across runs without an explicit sort.
+		// Frame each entry as a length-prefixed path followed by a fixed-size
+		// (32-byte) content digest, so a shifting path/content boundary cannot
+		// give two distinct migration sets the same byte stream. fs.WalkDir
+		// visits entries in lexical order, so the digest is stable across runs
+		// without an explicit sort.
 		var pathLen [8]byte
 
 		binary.BigEndian.PutUint64(pathLen[:], uint64(len(path)))
@@ -482,9 +463,8 @@ func dbTestAdvisoryKey(name string) int64 {
 }
 
 // dbTestQuoteIdent double-quotes a SQL identifier. Database names cannot be
-// passed as query parameters, so they are interpolated; the generated names use
-// a restricted character set, but quoting is kept as defence in depth and to
-// document that these are identifiers, not literals.
+// bound as query parameters, so they are interpolated; the generated names use a
+// restricted character set, and quoting adds defense in depth.
 func dbTestQuoteIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }

--- a/postgres/transaction.go
+++ b/postgres/transaction.go
@@ -8,8 +8,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// WithTx derives a context carrying tx, so GetContext resolves the transaction
-// rather than the pool it was opened on.
+// WithTx derives a context carrying tx, so GetContext resolves that transaction.
 //
 // [WithinTx] applies this for you and is what callers normally want. WithTx is
 // exported for the cases that own the transaction lifecycle themselves — a test
@@ -19,12 +18,11 @@ func WithTx(ctx context.Context, tx bun.IDB) context.Context {
 	return context.WithValue(ctx, ContextKey{}, tx)
 }
 
-// InTx reports whether ctx carries an open transaction rather than the
-// connection pool. It reports false when ctx carries no database at all, since
-// no handle is not an open transaction.
+// InTx reports whether ctx carries an open transaction. It reports false when
+// ctx carries the connection pool, and false when it carries no database at all.
 //
 // Work that must not hold a pooled connection — any call to an external service
-// — guards itself with this rather than trusting the convention to hold.
+// — guards itself with this.
 //
 // It reports true under [RunTransactionalTest], whose PassthroughTx is not a
 // *bun.DB. A test covering an outbound call must therefore use [RunDBTest],
@@ -41,18 +39,16 @@ func InTx(ctx context.Context) bool {
 }
 
 // WithinTx runs callback inside a transaction opened on the connection carried
-// by ctx, and installs that transaction on the context callback receives — so
-// every call made with it takes part rather than committing on its own.
+// by ctx, and installs that transaction on the context callback receives, so
+// every call made with it takes part in the transaction.
 //
-// The callback takes no transaction argument, which is the whole point: a
-// handle callers must thread through every nested call is a handle they can
-// forget, and forgetting it fails silently. With nothing to thread, the only
-// database handle reachable inside the callback is the transactional one.
+// The callback takes no transaction argument: the context it receives is the
+// only database handle reachable inside it, so no call can escape unnoticed.
 //
-// A nested call joins the transaction already in progress instead of opening a
-// savepoint, so one unit of work has one outcome and a rollback anywhere
-// discards all of it. A nested call therefore never reaches opts: an operation
-// depending on a specific isolation level must be the outermost transaction.
+// A nested call joins the transaction already in progress, so one unit of work
+// has one outcome and a rollback anywhere discards all of it. A nested call
+// never reaches opts: an operation depending on a specific isolation level must
+// be the outermost transaction.
 func WithinTx(ctx context.Context, opts *sql.TxOptions, callback func(ctx context.Context) error) error {
 	db, err := GetContext(ctx)
 	if err != nil {

--- a/postgres/transaction_test.go
+++ b/postgres/transaction_test.go
@@ -25,9 +25,9 @@ var migrations embed.FS
 var errRollback = errors.New("rollback")
 
 // testConfig points the tests at a throwaway database, named by the same
-// environment variable production uses so a developer configures one thing.
-// There is no default: a wrong guess would silently target whatever happens to
-// listen on the usual port, and these tests write.
+// environment variable production uses so a developer configures one thing. The
+// variable has no default, since these tests write and a guessed target could be
+// any database listening on the usual port.
 func testConfig(t *testing.T) postgres.Config {
 	t.Helper()
 
@@ -38,10 +38,9 @@ func testConfig(t *testing.T) postgres.Config {
 	return postgrespresets.NewDefault(pgdriver.WithDSN(dsn))
 }
 
-// writeProbe inserts one row through GetContext — the same way every consumer's
-// data-access code resolves its handle. That is what makes these tests
-// meaningful: they exercise the path that silently escaped the transaction,
-// not a handle threaded in by the test itself.
+// writeProbe inserts one row through GetContext, the way every consumer's
+// data-access code resolves its handle, so the tests exercise the path a real
+// caller takes.
 func writeProbe(ctx context.Context, t *testing.T, id string) {
 	t.Helper()
 
@@ -66,10 +65,8 @@ func probeCount(ctx context.Context, t *testing.T, id string) int {
 	return count
 }
 
-// TestWithinTxRollback is the regression test for the defect this package
-// carried: it fails against an implementation that leaves the pool on the
-// context, because the insert would then commit on its own and outlive the
-// rollback.
+// TestWithinTxRollback pins that the callback's writes go through the transaction.
+// The rollback takes the insert with it.
 func TestWithinTxRollback(t *testing.T) {
 	t.Parallel()
 
@@ -108,9 +105,9 @@ func TestWithinTxCommit(t *testing.T) {
 	})
 }
 
-// TestWithinTxNested covers the joining rule: an inner failure discards the
-// outer unit of work, because the inner call takes part in the transaction
-// already in progress rather than opening a savepoint it could roll back alone.
+// TestWithinTxNested covers the joining rule: the inner call takes part in the
+// transaction already in progress, so an inner failure discards the outer unit
+// of work too.
 func TestWithinTxNested(t *testing.T) {
 	t.Parallel()
 
@@ -172,8 +169,8 @@ func TestInTx(t *testing.T) {
 	})
 }
 
-// TestInTxNoContext covers a context nothing seeded. InTx answers "is a
-// transaction open", and no database handle at all is not one.
+// TestInTxNoContext covers a context nothing seeded: InTx answers "is a
+// transaction open", which a missing database handle is not.
 func TestInTxNoContext(t *testing.T) {
 	t.Parallel()
 

--- a/smtp/sender.go
+++ b/smtp/sender.go
@@ -42,9 +42,8 @@ func (mailUsers MailUsers) Emails() []string {
 	})
 }
 
-// Sender delivers a rendered mail template to a set of recipients. Callers
-// depend on this interface rather than a concrete type so the delivery backend
-// can be swapped per environment: a real SMTP server in production, a writer in
+// Sender delivers a rendered mail template to a set of recipients. The delivery
+// backend swaps per environment: a real SMTP server in production, a writer in
 // local development, an in-memory recorder in tests.
 type Sender interface {
 	// SendMail renders template tName from t with data and delivers the result

--- a/smtp/sender.prod.go
+++ b/smtp/sender.prod.go
@@ -14,16 +14,13 @@ import (
 
 // DefaultTimeout bounds a single delivery when ProdSender leaves Timeout unset.
 //
-// Bounded rather than unlimited on purpose. net/smtp dials with no deadline, so an SMTP host that
-// accepts the connection and then goes quiet — a security-group change, a provider throttling by
-// stalling — holds the calling goroutine forever. A caller who must remember to set a timeout is a
-// caller who eventually forgets, and the resulting leak reports nothing: the request that spawned
-// the send has already returned, so there is no latency signal, no error rate and no failing probe.
-// Only a slow climb in memory.
+// net/smtp dials with no deadline. An SMTP host that accepts the connection and then goes quiet
+// holds the calling goroutine. The request that spawned the send has already returned, so the leak
+// shows up only as a slow climb in memory.
 const DefaultTimeout = 30 * time.Second
 
-// ErrNoAuthSupport is returned when the server does not advertise the AUTH extension. Continuing
-// would mean either skipping authentication or offering credentials the server never asked for.
+// ErrNoAuthSupport is returned when the server does not advertise the AUTH extension. Delivery
+// stops there: every message goes out authenticated.
 var ErrNoAuthSupport = errors.New("SMTP server does not support AUTH")
 
 // ProdSender delivers mail through a real SMTP server using net/smtp. Its
@@ -43,16 +40,14 @@ type ProdSender struct {
 	ForceUnencryptedTls bool `json:"forceUnencryptedTLS" yaml:"forceUnencryptedTLS"`
 
 	// Timeout bounds one delivery end to end. Connect, handshake, authentication and the message
-	// body share a single budget, because a stalled server can hold any of those steps.
-	// Non-positive selects DefaultTimeout.
+	// body share a single budget. Non-positive selects DefaultTimeout.
 	Timeout time.Duration `json:"timeout" yaml:"timeout"`
 }
 
 // SendMail renders tName from t with data and delivers it, driving the SMTP exchange directly.
 //
-// [smtp.SendMail] would be the obvious call, and this is a transcription of what it does — but it
-// dials internally with no deadline, so nothing a caller can do bounds the exchange once the
-// connection is accepted.
+// This transcribes [smtp.SendMail], which dials internally with no deadline. Driving the exchange
+// here puts the delivery deadline on the connection.
 func (sender *ProdSender) SendMail(to MailUsers, t *template.Template, tName string, data any) error {
 	writer := bytes.NewBuffer(nil)
 
@@ -99,8 +94,7 @@ func (sender *ProdSender) SendMail(to MailUsers, t *template.Template, tName str
 		return fmt.Errorf("send email: %w", err)
 	}
 
-	// Closing the body is what commits the message, so its error is the server's verdict on the
-	// delivery — not the droppable error of a cleanup close.
+	// Closing the body commits the message, so its error is the server's verdict on the delivery.
 	err = body.Close()
 	if err != nil {
 		return fmt.Errorf("send email: %w", err)
@@ -115,8 +109,7 @@ func (sender *ProdSender) SendMail(to MailUsers, t *template.Template, tName str
 }
 
 // Ping reports whether the SMTP server is reachable and accepts the configured credentials. It
-// shares SendMail's timeout: a readiness probe that can hang is one that reports nothing about the
-// very outage it exists to detect.
+// shares SendMail's timeout, so the probe always returns.
 func (sender *ProdSender) Ping() error {
 	client, host, err := sender.dial()
 	if err != nil {
@@ -157,13 +150,9 @@ func (sender *ProdSender) auth() smtp.Auth {
 
 // dial connects to the SMTP server with the delivery's deadline already set on the connection.
 //
-// The deadline is the whole reason for dialing here rather than through [smtp.SendMail] or
-// [smtp.Dial]: both dial internally with no deadline, so a caller cannot bound what happens once the
-// connection is accepted. net/smtp offers no context and no cancellation, which leaves the
-// connection's own deadline as the only mechanism reaching every subsequent read and write.
-//
-// The dialer takes a background context because [Sender] carries none; the timeout, not the context,
-// is what bounds this.
+// net/smtp offers no context and no cancellation, so the connection's own deadline reaches every
+// subsequent read and write. The dialer takes a background context because [Sender] carries none;
+// the timeout is what bounds this.
 func (sender *ProdSender) dial() (*smtp.Client, string, error) {
 	timeout := sender.timeout()
 
@@ -179,7 +168,7 @@ func (sender *ProdSender) dial() (*smtp.Client, string, error) {
 		return nil, "", fmt.Errorf("dial SMTP server: %w", err)
 	}
 
-	// Measured from here, so the budget covers the whole exchange rather than restarting per step.
+	// Measured from here, so one budget covers the whole exchange.
 	err = conn.SetDeadline(time.Now().Add(timeout))
 	if err != nil {
 		_ = conn.Close()
@@ -197,12 +186,11 @@ func (sender *ProdSender) dial() (*smtp.Client, string, error) {
 	return client, host, nil
 }
 
-// negotiate performs the handshake [smtp.SendMail] would have done: upgrade to TLS whenever the
-// server offers it, then authenticate, refusing to continue when the server does not advertise AUTH.
+// negotiate performs the handshake: upgrade to TLS whenever the server offers it, then
+// authenticate. A server that does not advertise AUTH stops the delivery.
 //
-// The ordering is the security-relevant part and matches the standard library's: STARTTLS is
-// attempted before any credential is offered, so an eavesdropper sees the upgrade rather than the
-// password.
+// The ordering is security-relevant. STARTTLS is attempted before any credential is offered, so
+// credentials only cross an upgraded connection.
 func (sender *ProdSender) negotiate(client *smtp.Client, host string) error {
 	ok, _ := client.Extension("STARTTLS")
 	if ok {

--- a/smtp/sender.prod_test.go
+++ b/smtp/sender.prod_test.go
@@ -14,10 +14,8 @@ import (
 	"github.com/a-novel-kit/golib/smtp"
 )
 
-// ProdSender drives the SMTP exchange itself rather than calling net/smtp.SendMail, because
-// SendMail dials internally and so cannot be bounded. That transcription is what these tests cover:
-// the handshake still happens in the right order, and — the reason for the change — a server that
-// accepts a connection and then goes quiet no longer holds the caller forever.
+// These tests cover ProdSender's own SMTP exchange. The handshake happens in the right order, and
+// a server that accepts a connection and then goes quiet releases the caller on the timeout.
 //
 // The fake server is a real listener speaking enough SMTP to complete a transaction, so the client
 // under test is the real net/smtp client on a real socket.
@@ -25,14 +23,13 @@ import (
 // fakeServer is a minimal SMTP server for one connection.
 type fakeServer struct {
 	listener net.Listener
-	// stall makes the server accept the connection and then never write a greeting, which is the
-	// failure mode the timeout exists for: the dial succeeds, so no dial timeout can help.
+	// stall makes the server accept the connection and then never write a greeting. The dial
+	// succeeds, so only a deadline on the connection ends the wait.
 	stall bool
 	// transcript records the commands the client sent, in order.
 	transcript []string
-	// stop releases a stalled handler at cleanup; done reports that serve has returned. Separate
-	// channels on purpose — a stalled handler waiting on the one its own defer closes would
-	// deadlock against the cleanup waiting for it.
+	// stop releases a stalled handler at cleanup; done reports that serve has returned. They are
+	// separate channels: the handler waits on stop and the cleanup waits on done.
 	stop chan struct{}
 	done chan struct{}
 }
@@ -76,8 +73,7 @@ func (s *fakeServer) serve() {
 	defer func() { _ = conn.Close() }()
 
 	if s.stall {
-		// Accept and say nothing. Without a deadline on the connection the client waits here
-		// indefinitely for a greeting that never comes.
+		// Accept and say nothing. The client waits here for a greeting until its deadline fires.
 		<-s.stop
 
 		return
@@ -112,8 +108,8 @@ func (s *fakeServer) serve() {
 
 		switch {
 		case strings.HasPrefix(line, "EHLO"):
-			// AUTH is advertised; STARTTLS deliberately is not, so the client must skip the upgrade
-			// rather than fail. PlainAuth permits plaintext credentials to a loopback server.
+			// AUTH is advertised and STARTTLS is not, so the client skips the upgrade and carries on.
+			// PlainAuth permits plaintext credentials to a loopback server.
 			write("250-fake")
 			write("250 AUTH PLAIN")
 		case strings.HasPrefix(line, "AUTH"):
@@ -157,8 +153,7 @@ func TestProdSenderSendMail(t *testing.T) {
 		Email: "noreply@example.com",
 		// The fake accepts any credential; what matters is that AUTH is attempted at all.
 		Password: "hunter2",
-		// PlainAuth checks this against the server it is talking to, so Domain is the SMTP host
-		// rather than the mail domain — a pre-existing coupling this change does not alter.
+		// PlainAuth checks this against the server it is talking to, so Domain is the SMTP host.
 		Domain: host,
 	}
 
@@ -175,7 +170,7 @@ func TestProdSenderSendMail(t *testing.T) {
 	require.Contains(t, joined, "DATA")
 	require.Contains(t, joined, "QUIT")
 
-	// AUTH before MAIL: the transcription must not start a transaction unauthenticated.
+	// AUTH before MAIL. The transaction starts only once the client is authenticated.
 	authAt := strings.Index(joined, "AUTH")
 	mailAt := strings.Index(joined, "MAIL FROM")
 	require.Less(t, authAt, mailAt, "AUTH must precede MAIL FROM")
@@ -184,8 +179,7 @@ func TestProdSenderSendMail(t *testing.T) {
 func TestProdSenderRefusesServerWithoutAuth(t *testing.T) {
 	t.Parallel()
 
-	// A server advertising no AUTH would previously have had credentials skipped silently; the
-	// send must fail rather than deliver unauthenticated.
+	// A server advertising no AUTH fails the send. Every message goes out authenticated.
 	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
@@ -241,10 +235,9 @@ func TestProdSenderTimesOutOnStalledServer(t *testing.T) {
 		Timeout: 150 * time.Millisecond,
 	}
 
-	// The connection is accepted, so a dial timeout would not help — only a deadline on the
-	// connection bounds the wait for a greeting that never arrives. Without one this blocks
-	// forever, and the goroutine holding it is invisible: the HTTP request that spawned it has
-	// already returned 202.
+	// The connection is accepted, so the deadline on the connection bounds the wait for a greeting.
+	// The goroutine holding it is invisible: the HTTP request that spawned it has already returned
+	// 202.
 	start := time.Now()
 
 	err := sender.SendMail(
@@ -266,9 +259,8 @@ func TestProdSenderPingTimesOutOnStalledServer(t *testing.T) {
 
 	server := newFakeServer(t, true)
 
-	// Ping backs the readiness probe. Unbounded, the probe that exists to report a broken SMTP
-	// server hangs instead of reporting it — so the one signal an operator would look at is the
-	// one the failure disables.
+	// Ping backs the readiness probe, so it returns within the timeout and reports the outage it
+	// exists to detect.
 	sender := &smtp.ProdSender{
 		Addr:    server.addr(),
 		Email:   "noreply@example.com",
@@ -285,10 +277,10 @@ func TestProdSenderPingTimesOutOnStalledServer(t *testing.T) {
 func TestProdSenderDefaultTimeoutApplies(t *testing.T) {
 	t.Parallel()
 
-	// An unset Timeout must not mean "unbounded" — that is the config every caller forgets.
+	// An unset Timeout selects DefaultTimeout.
 	sender := &smtp.ProdSender{Addr: "192.0.2.1:25", Email: "noreply@example.com"}
 
 	require.Positive(t, smtp.DefaultTimeout)
 
-	_ = sender // the constant is the contract; dialing TEST-NET-1 here would cost DefaultTimeout
+	_ = sender // the constant is the contract; dialing TEST-NET-1 costs DefaultTimeout
 }

--- a/smtp/smtptest/sender.go
+++ b/smtp/smtptest/sender.go
@@ -12,9 +12,8 @@ import (
 	"github.com/a-novel-kit/golib/smtp"
 )
 
-// ErrPing is returned by Sender.Ping. Production code that pings a test
-// sender almost always indicates a misconfiguration where the real SMTP
-// sender was meant to be wired in.
+// ErrPing is returned by Sender.Ping. Reaching it means this test sender is
+// wired where the real SMTP sender belongs.
 var ErrPing = errors.New("pinging smtptest sender: make sure this is not a misconfiguration")
 
 // Mail is the captured form of a single SendMail call.
@@ -35,8 +34,7 @@ func NewSender() *Sender {
 	return &Sender{}
 }
 
-// SendMail satisfies smtp.Sender by appending a captured Mail entry rather
-// than reaching any network.
+// SendMail satisfies smtp.Sender by appending a captured Mail entry.
 func (sender *Sender) SendMail(to smtp.MailUsers, _ *template.Template, _ string, data any) error {
 	sender.mu.Lock()
 	defer sender.mu.Unlock()
@@ -49,8 +47,7 @@ func (sender *Sender) SendMail(to smtp.MailUsers, _ *template.Template, _ string
 	return nil
 }
 
-// Ping always returns ErrPing — production code should never end up calling
-// it.
+// Ping always returns ErrPing.
 func (sender *Sender) Ping() error {
 	return ErrPing
 }
@@ -58,11 +55,10 @@ func (sender *Sender) Ping() error {
 // FindMail returns the first captured Mail for which cmp returns true, or
 // (nil, false) if none matched.
 //
-// cmp runs after the lock is released, against a snapshot of the captured
-// pointers: this keeps a slow comparator from blocking concurrent SendMail
-// callers, and a re-entrant one (that calls back into SendMail) from
-// deadlocking. The returned *Mail aliases the captured entry — callers must
-// not mutate it.
+// cmp runs against a snapshot of the captured pointers, after the lock is
+// released, so a slow comparator cannot block concurrent SendMail callers and a
+// re-entrant one cannot deadlock. The returned *Mail aliases the captured entry;
+// callers must not mutate it.
 func (sender *Sender) FindMail(cmp func(*Mail) bool) (*Mail, bool) {
 	sender.mu.RLock()
 	snapshot := append([]*Mail(nil), sender.mails...)

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -1,11 +1,9 @@
 // Package transaction declares the scope a unit of work runs in, independently
 // of what stores it.
 //
-// It exists as its own package, rather than alongside a driver, so that a
-// caller can name what it needs without gaining access to a database. Its
-// entire dependency list is context: nothing here can reach a connection, a
-// pool, or a driver symbol, which is what makes it safe to import from a layer
-// that is supposed to stay free of persistence detail.
+// Its entire dependency list is context: nothing here reaches a connection, a
+// pool, or a driver symbol, so a layer that must stay free of persistence detail
+// can import it and still name the scope it needs.
 //
 // Implementations live with their driver — see
 // [github.com/a-novel-kit/golib/postgres.Transactor] for the PostgreSQL one.
@@ -17,21 +15,15 @@ import "context"
 // the context it hands the callback either commits together or is rolled back
 // together.
 //
-// The callback receives no transaction handle. That is deliberate, and it is
-// the reason this interface exists rather than callers driving a driver
-// directly: a handle callers are expected to thread through every nested call
-// is a handle they can forget, and forgetting it fails silently — the calls run
-// outside the transaction, the block commits, and the tests pass. With nothing
-// to thread, the mistake cannot be written.
+// The callback receives no transaction handle: the context it is given is the
+// only way to reach the transaction, so no call can escape it unnoticed.
 //
-// Two behaviours are part of the contract, and an implementation that does not
-// honour them does not satisfy this interface.
+// Two behaviors are part of the contract, and an implementation must honor both.
 //
-// A nested WithinTx joins the transaction already in progress rather than
-// opening a nested one, so a rollback anywhere discards the whole outermost
-// unit of work. An inner operation that treats a failure as locally
-// recoverable is therefore discarding its caller's work too. Nesting is legal,
-// but it should be a deliberate choice rather than an accident of composition.
+// A nested WithinTx joins the transaction already in progress, so a rollback
+// anywhere discards the whole outermost unit of work. An inner operation that
+// treats a failure as locally recoverable is therefore discarding its caller's
+// work too, which makes nesting a deliberate choice.
 //
 // Nothing that talks to an external service may run inside the callback. An
 // open transaction holds a pooled connection for as long as it lasts, and

--- a/transaction/transactiontest/transactor.go
+++ b/transaction/transactiontest/transactor.go
@@ -6,12 +6,10 @@
 // body without a database while the test can still assert that the body ran
 // inside a transaction at all.
 //
-// It does not implement transactions. Nothing is rolled back, because there is
-// nothing to roll back — an in-memory double cannot undo whatever the callback
-// did to the fakes around it. What it verifies is that the caller opened a
-// scope and propagated the callback's outcome; that a rollback actually
-// discards writes is a property of the real implementation, and belongs in a
-// test that has a database.
+// Nothing is rolled back: an in-memory double cannot undo what the callback did
+// to the fakes around it. It verifies that the caller opened a scope and
+// propagated the callback's outcome; that a rollback discards writes belongs in
+// a test that has a database.
 package transactiontest
 
 import (
@@ -33,10 +31,9 @@ func NewTransactor() *Transactor {
 	return &Transactor{}
 }
 
-// NewFailingTransactor returns a Transactor that refuses to run the callback at
-// all and returns err instead, standing in for a transaction that could not be
-// opened. The callback not running is the point: an operation that reports
-// success when its unit of work never started is the failure this reproduces.
+// NewFailingTransactor returns a Transactor that returns err without running the
+// callback, standing in for a transaction that could not be opened. It
+// reproduces an operation whose unit of work never started.
 func NewFailingTransactor(err error) *Transactor {
 	return &Transactor{err: err}
 }
@@ -57,7 +54,7 @@ func (transactor *Transactor) WithinTx(ctx context.Context, fn func(ctx context.
 }
 
 // Calls reports how many times WithinTx was entered, so a test can assert an
-// operation opened exactly one scope rather than one per write.
+// operation opened exactly one scope.
 func (transactor *Transactor) Calls() int {
 	transactor.mu.Lock()
 	defer transactor.mu.Unlock()

--- a/transaction/transactiontest/transactor_test.go
+++ b/transaction/transactiontest/transactor_test.go
@@ -41,8 +41,7 @@ func TestTransactorPropagatesTheCallbackError(t *testing.T) {
 }
 
 // TestFailingTransactorSkipsTheCallback covers the property the failing double
-// exists for: an operation that reports success when its unit of work never
-// started is the bug it reproduces, so the callback must not run.
+// exists for: when the transaction cannot be opened, the callback must not run.
 func TestFailingTransactorSkipsTheCallback(t *testing.T) {
 	t.Parallel()
 
@@ -71,8 +70,8 @@ func TestTransactorCountsNestedCalls(t *testing.T) {
 	require.Equal(t, 2, transactor.Calls())
 }
 
-// TestTransactorSatisfiesTheInterface fails to compile rather than fails to
-// run if the double drifts from the contract it stands in for.
+// TestTransactorSatisfiesTheInterface fails to compile if the double drifts from
+// the contract it stands in for.
 func TestTransactorSatisfiesTheInterface(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Comment-only sweep: cut verbosity, state the positive claim instead of the contrast, and drop justification of alternatives nobody wrote.
- 264 comment lines rewritten to 194 and 8 deleted outright across 18 files, plus a second pass over `smtp/sender.prod.go` and its test, which landed in `abb3edd` after this branch was cut.
- Exported API docs are intact: every exported symbol keeps a doc comment starting with its name, every error variable still states its triggering condition, and `postgres.PingTimeout` gained the doc its documented sibling already had.

## What a reviewer should scrutinise

- **`postgres/presets/default.go` lost a paragraph defending the absence of a field.** The `MaxIdleConns` doc explained why `MaxOpenConns` is *not* a field. The causal chain that matters survives — `database/sql` keeps 2 idle, so every call past the second pays a TCP + TLS + auth handshake, and 10 stays under a stock `max_connections` of 100 across replicas.
- **`smtp/sender.prod.go` is the newest code in the repo and got the same treatment as the rest.** `DefaultTimeout`, `SendMail`, `dial`, `negotiate` and `Ping` each carried several lines arguing against `net/smtp.SendMail`. The constraint survives in every case — `net/smtp` offers no context and no cancellation, so the connection's own deadline is what reaches every read and write — and the argument does not. The security-relevant handshake ordering (STARTTLS before any credential) is kept.
- **`postgres/test.go`** was the heaviest file. `RunDBTest`, `dbTestCloneMu` and the digest-framing block all shed prose; the shifting-boundary hazard, the lexical-order guarantee, and the `CREATE … TEMPLATE` session constraint are kept.
- **British spellings corrected** in `transaction/transaction.go`. `TestDefaultHonoursTheOverride` keeps its spelling — it is an identifier, and renaming it is a code change.

## Breaking changes

None. No exported symbol, signature or behaviour changed.

## Test plan

- [x] `gofmt -l .` clean, `go build ./...`, `go vet ./...` pass
- [x] `go tool -modfile=golangci-lint.mod golangci-lint run ./...` — 0 issues
- [x] `go test ./smtp/...` green (the files this branch reworked most)
- [ ] CI green