### PR TITLE
docs: sweep counterfactuals the earlier pass missed

### DIFF
--- a/smtp/sender.debug.go
+++ b/smtp/sender.debug.go
@@ -7,9 +7,9 @@ import (
 	"text/template"
 )
 
-// DebugSender is a Sender that renders the mail template to an io.Writer
-// instead of delivering it, for local development where no SMTP server is
-// available. Recipients are ignored and Ping always succeeds.
+// DebugSender is a Sender that renders the mail template to an io.Writer, for local
+// development where no SMTP server is available. Recipients are ignored and Ping always
+// succeeds.
 type DebugSender struct {
 	writer io.Writer
 }

--- a/smtp/sender.go
+++ b/smtp/sender.go
@@ -1,7 +1,7 @@
 // Package smtp sends templated transactional email through a pluggable Sender.
 // A Sender renders a text/template into the message body and delivers it; the
 // package ships a production sender backed by net/smtp and a debug sender that
-// writes the rendered body to a writer instead of dialing a server.
+// writes the rendered body to a writer.
 package smtp
 
 import (

--- a/smtp/smtptest/sender.go
+++ b/smtp/smtptest/sender.go
@@ -1,5 +1,5 @@
 // Package smtptest provides an in-memory smtp.Sender for unit and integration
-// tests. Its Sender records every SendMail call instead of reaching a network,
+// tests. Its Sender records every SendMail call in memory,
 // so a test can substitute *smtptest.Sender wherever an smtp.Sender is expected
 // and later assert on what was sent.
 package smtptest


### PR DESCRIPTION
## Summary

Follow-up to the comment sweep. The earlier pass verified itself against its own diff, so comments it chose not to rewrite were never re-checked once the bar tightened to "no counterfactuals, affirmative sentences". This is the tree-wide re-scan.

Three comments, all describing the same thing: the package's test and debug doubles were documented by what they *avoid* rather than what they do.

- `smtp/sender.debug.go` — `DebugSender` "renders the mail template to an io.Writer instead of delivering it" → renders it to the writer, full stop
- `smtp/sender.go` — package doc, "writes the rendered body to a writer instead of dialing a server"
- `smtp/smtptest/sender.go` — "records every SendMail call instead of reaching a network" → "records every SendMail call in memory"

## Breaking changes

None.

## Test plan

- [x] `gofmt -l .` clean, `go build ./...` passes
- [x] `go tool -modfile=golangci-lint.mod golangci-lint run ./...` — 0 issues
- [x] diff contains no non-comment lines
- [ ] CI green