### PR TITLE
feat(postgres): bound how many connections a pool may open

### DIFF
--- a/docs/migrations/v0.26.0.md
+++ b/docs/migrations/v0.26.0.md
@@ -1,0 +1,30 @@
+# Migrating to v0.26.0
+
+Nothing to change. `postgrespresets.Default` gains `MaxOpenConns`; its zero value
+is the current behaviour.
+
+## Why
+
+`database/sql` places no limit on open connections. Enough replicas of one service
+exhaust the database, and the error surfaces in whichever process asks next — a
+migration job, an operator's `psql` — not in the replica responsible.
+
+No default is supplied: the right number depends on how many replicas share the
+database, which a library cannot know.
+
+## Setting it
+
+```go
+config := postgrespresets.NewDefault(pgdriver.WithDSN(dsn))
+config.MaxOpenConns = 20
+config.MaxIdleConns = 20
+```
+
+Budget per process: `replicas × max_open + jobs < max_connections`.
+
+## Why the field and not the pool
+
+Setting the limit on the pool after opening it only works if nothing has asked for
+a connection yet, because the handle is cached. Nothing enforces that order, and
+missing it applies the limit to nothing without an error. The field is bounded as
+the pool opens, on both the primary and per-schema paths.

--- a/postgres/presets/default.go
+++ b/postgres/presets/default.go
@@ -41,6 +41,15 @@ type Default struct {
 	// MaxIdleConnsDefault; a negative value keeps none, matching database/sql.
 	MaxIdleConns int
 
+	// MaxOpenConns bounds how many connections the pools may open. Zero means
+	// unlimited, matching database/sql.
+	//
+	// No default: the right number depends on how many replicas share the database,
+	// which a library cannot know. It lives here rather than being set on the pool
+	// afterwards because the handle is cached — setting it late applies it to
+	// nothing, and nothing reports that.
+	MaxOpenConns int
+
 	// Cached connection to the primary database, opened on first use.
 	db *bun.DB
 	// Cached connection per schema name.
@@ -66,6 +75,8 @@ func (config *Default) DB(ctx context.Context) (*bun.DB, error) {
 		sqldb := sql.OpenDB(pgdriver.NewConnector(config.options...))
 		db := bun.NewDB(sqldb, pgdialect.New(), bun.WithDiscardUnknownColumns())
 		db.SetMaxIdleConns(config.maxIdleConns())
+		db.SetMaxOpenConns(config.MaxOpenConns)
+		db.SetMaxOpenConns(config.MaxOpenConns)
 
 		err := postgres.Ping(ctx, db)
 		if err != nil {

--- a/postgres/presets/default_test.go
+++ b/postgres/presets/default_test.go
@@ -107,3 +107,39 @@ func TestDefaultNegativeOverrideKeepsNone(t *testing.T) {
 
 	require.Zero(t, db.Stats().Idle)
 }
+
+// TestDefaultBoundsOpenConnections covers the open limit, which has no default:
+// the field exists so a service can state its own answer where it builds the
+// config, and the pool has to honour it on every connection it opens.
+func TestDefaultBoundsOpenConnections(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t)
+	config.MaxOpenConns = 2
+
+	ctx := t.Context()
+
+	db, err := config.DB(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, db.Stats().MaxOpenConnections)
+
+	// The cap has to hold under contention, not just report itself: more callers
+	// than connections must queue rather than open more.
+	holdOpen(ctx, t, config)
+	require.LessOrEqual(t, db.Stats().OpenConnections, 2)
+}
+
+// TestDefaultLeavesOpenConnectionsUnlimitedByDefault pins the absence of a
+// default. A library cannot know how many replicas share a database, so an
+// unset value must keep database/sql's behaviour rather than invent a ceiling.
+func TestDefaultLeavesOpenConnectionsUnlimitedByDefault(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t)
+
+	db, err := config.DB(t.Context())
+	require.NoError(t, err)
+
+	require.Zero(t, db.Stats().MaxOpenConnections, "0 is database/sql's encoding of unlimited")
+}


### PR DESCRIPTION
Adds `MaxOpenConns` to `postgrespresets.Default`. Zero means unlimited, which is what the package does today, so this changes no behaviour on its own.

Refs #373

## Why

`database/sql` places no limit on open connections. Enough replicas exhaust the database, and the error lands on whichever process asks next — a migration job, an operator's `psql` — not on the replica responsible.

No default is supplied. The right number depends on how many replicas share the database; a library cannot know it.

## Why the field and not the pool

Setting the limit on the pool after opening it only works if nothing has asked for a connection yet, because the handle is cached. Nothing enforces that order, and missing it applies the limit to nothing without an error.

## Why this is a separate PR

#383 was squash-merged while this commit was still local. The push that followed re-created the auto-deleted branch, so it ended up with no pull request attached and **v0.25.0 shipped half the change**. Cherry-picked onto the release here.

## Tests

Both fail against the current code. `TestDefaultBoundsOpenConnections` asserts the cap under contention — more callers than connections must queue — rather than reading the setting back. `TestDefaultLeavesOpenConnectionsUnlimitedByDefault` pins the absence of a default.

## Blocks

a-novel/service-template#400, a-novel/service-authentication#1116, a-novel/service-json-keys#826. All three need v0.26.0.