### PR TITLE
docs: file the pool-limit note under the version that shipped

### DIFF
--- a/docs/migrations/v0.25.1.md
+++ b/docs/migrations/v0.25.1.md
@@ -1,4 +1,4 @@
-# Migrating to v0.26.0
+# Migrating to v0.25.1
 
 Nothing to change. `postgrespresets.Default` gains `MaxOpenConns`; its zero value
 is the current behaviour.

--- a/postgres/presets/default.go
+++ b/postgres/presets/default.go
@@ -45,9 +45,11 @@ type Default struct {
 	// unlimited, matching database/sql.
 	//
 	// No default: the right number depends on how many replicas share the database,
-	// which a library cannot know. It lives here rather than being set on the pool
-	// afterwards because the handle is cached — setting it late applies it to
-	// nothing, and nothing reports that.
+	// which a library cannot know.
+	//
+	// The limit applies as a pool opens. Setting it on the handle afterwards stops
+	// working once anything has taken a connection, because the handle is cached;
+	// past that point it applies to nothing and reports nothing.
 	MaxOpenConns int
 
 	// Cached connection to the primary database, opened on first use.


### PR DESCRIPTION
The `MaxOpenConns` migration note was written as `v0.26.0.md` and the change released as **v0.25.1**. Anyone looking up the version they are on finds nothing.

Also drops a contrast clause from the `MaxOpenConns` doc comment, per `document-code`'s "write the choice, not the rejected alternative". The failure mode it described is worth keeping and stays, stated once as a fact.