### PR TITLE
feat(httpf): add SendJSONStatus and deprecate SendJSON

### DIFF
--- a/httpf/json.go
+++ b/httpf/json.go
@@ -10,12 +10,22 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 )
 
-// SendJSON encodes data as JSON to w with a JSON content type and records the outcome
-// on the span. An encoding failure is reported on the span; by then the status line is
-// already sent, so the body may be truncated. The caller sets any non-200 status before
-// calling.
-func SendJSON[Data any](_ context.Context, w http.ResponseWriter, span trace.Span, data Data) {
+// SendJSONStatus encodes data as JSON to w under status, and records the outcome on the
+// span.
+//
+// The status is a parameter rather than something the caller sends first, because
+// net/http freezes the outbound header set when the status line goes out. A caller that
+// writes the status first has its Content-Type discarded and answers text/plain; one
+// that writes it afterwards gets a "superfluous WriteHeader" and keeps the 200. Owning
+// both is the only order that answers JSON under a status other than 200.
+//
+// An encoding failure is reported on the span. The status line is already sent by then,
+// so the body may be truncated.
+func SendJSONStatus[Data any](
+	_ context.Context, w http.ResponseWriter, span trace.Span, status int, data Data,
+) {
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 
 	err := json.NewEncoder(w).Encode(data)
 	if err != nil {
@@ -25,4 +35,14 @@ func SendJSON[Data any](_ context.Context, w http.ResponseWriter, span trace.Spa
 	}
 
 	otel.ReportSuccessNoContent(span)
+}
+
+// SendJSON encodes data as JSON to w with a 200 status, and records the outcome on the
+// span.
+//
+// Deprecated: use [SendJSONStatus], passing http.StatusOK for the same response. This
+// signature cannot answer under any other status — a caller that sends one first loses
+// the JSON content type, which is what [SendJSONStatus] exists to make impossible.
+func SendJSON[Data any](ctx context.Context, w http.ResponseWriter, span trace.Span, data Data) {
+	SendJSONStatus(ctx, w, span, http.StatusOK, data)
 }

--- a/httpf/json_test.go
+++ b/httpf/json_test.go
@@ -1,0 +1,149 @@
+package httpf_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/a-novel-kit/golib/httpf"
+)
+
+// Every case here goes through a real server, because httptest.ResponseRecorder cannot
+// show the defect: its Header() stays live after WriteHeader, so a discarded
+// Content-Type still reads back as set. Only a response that has crossed a socket
+// reports what a client would actually receive.
+
+type response struct {
+	status      int
+	contentType string
+	body        string
+}
+
+func call(t *testing.T, handler http.HandlerFunc) response {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	res, err := server.Client().Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	return response{
+		status:      res.StatusCode,
+		contentType: res.Header.Get("Content-Type"),
+		body:        string(body),
+	}
+}
+
+func TestSendJSONStatus(t *testing.T) {
+	t.Parallel()
+
+	span := noop.Span{}
+
+	testCases := []struct {
+		name string
+
+		status int
+		data   any
+
+		expectBody string
+	}{
+		{
+			name:       "OK",
+			status:     http.StatusOK,
+			data:       map[string]string{"hello": "world"},
+			expectBody: `{"hello":"world"}`,
+		},
+		{
+			// The case the previous signature could not express. Both live 201 handlers
+			// declare content: application/json for it in their openapi.yaml.
+			name:       "Created",
+			status:     http.StatusCreated,
+			data:       map[string]string{"id": "abc"},
+			expectBody: `{"id":"abc"}`,
+		},
+		{
+			name:       "Accepted",
+			status:     http.StatusAccepted,
+			data:       []string{"queued"},
+			expectBody: `["queued"]`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := call(t, func(w http.ResponseWriter, r *http.Request) {
+				httpf.SendJSONStatus(r.Context(), w, span, testCase.status, testCase.data)
+			})
+
+			require.Equal(t, testCase.status, got.status)
+			require.Equal(t, "application/json", got.contentType)
+			require.JSONEq(t, testCase.expectBody, got.body)
+		})
+	}
+}
+
+func TestSendJSONKeepsTheJSONContentType(t *testing.T) {
+	t.Parallel()
+
+	// The deprecated signature still answers 200 with a JSON content type, so the 14
+	// call sites that never set a status are unaffected by the change.
+	got := call(t, func(w http.ResponseWriter, r *http.Request) {
+		httpf.SendJSON(r.Context(), w, noop.Span{}, map[string]int{"n": 1})
+	})
+
+	require.Equal(t, http.StatusOK, got.status)
+	require.Equal(t, "application/json", got.contentType)
+	require.JSONEq(t, `{"n":1}`, got.body)
+}
+
+// Pins the behaviour the new signature exists to make unreachable: net/http freezes the
+// header set at WriteHeader, so a Content-Type written afterwards never leaves the
+// process and the client is told text/plain.
+//
+// This is what both live 201 handlers do today, and what SendJSON's own doc used to
+// prescribe.
+func TestWritingTheStatusFirstDiscardsTheContentType(t *testing.T) {
+	t.Parallel()
+
+	got := call(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "abc"})
+	})
+
+	require.Equal(t, http.StatusCreated, got.status)
+	require.NotEqual(t, "application/json", got.contentType,
+		"if this ever passes, net/http changed and the whole rationale needs revisiting")
+	require.Contains(t, got.contentType, "text/plain")
+}
+
+// The recorder is why no existing test caught this.
+func TestResponseRecorderCannotObserveTheDiscard(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	recorder.WriteHeader(http.StatusCreated)
+	recorder.Header().Set("Content-Type", "application/json")
+
+	// A naive assertion against the recorder passes, while a real client is served
+	// text/plain — see the test above.
+	require.Equal(t, "application/json", recorder.Header().Get("Content-Type"),
+		"the recorder reports the header a real response would have dropped")
+}


### PR DESCRIPTION
Closes #371, per your "sounds good" on the staged rollout. Stage 1: add the new symbol, deprecate the old. Consumers migrate separately.

## The defect

`SendJSON` set `Content-Type` and left the status to the caller — and its doc told the caller to send that status **first**:

> The caller sets any non-200 status before calling.

`net/http` freezes the outbound header set at `WriteHeader`, so the content type was discarded. Verified against a real server:

```
WriteHeader(201) then SendJSON  ->  Content-Type: text/plain; charset=utf-8   status=201
```

Both live 201 handlers do exactly what the doc says, and both declare `content: application/json` for that response in their `openapi.yaml`. The other 14 call sites are correct **by accident** — they simply never call `WriteHeader`.

## The fix

`SendJSONStatus` takes the status, which makes the ordering **unrepresentable** rather than documented against — the same move as `Derive` taking `[]byte` in jwt#497, and the `InTx` fix earlier in this milestone.

`SendJSON` delegates to it with `http.StatusOK` and is deprecated. Its signature *cannot* express another status without reintroducing the defect, which is the honest reason to retire it rather than "we prefer the new name".

**Delegating also makes the two broken call sites loud.** They still call `WriteHeader` first, so the second write now draws net/http's `superfluous response.WriteHeader call` warning until they migrate. They were failing silently before; now they complain. That seemed strictly better than leaving them quiet during the migration window.

## Tests — `httpf` had none at all

Which is most of the explanation for how this survived.

Every case runs against a **real server**, because `httptest.ResponseRecorder` structurally cannot show the defect: its `Header()` map stays live after `WriteHeader`, so a discarded content type still reads back as set.

Two of the tests exist to pin things I reasoned about rather than to cover the new function:

- `TestWritingTheStatusFirstDiscardsTheContentType` pins net/http's actual behaviour. If it ever passes, net/http changed and this whole rationale needs revisiting.
- `TestResponseRecorderCannotObserveTheDiscard` pins the recorder blindness itself — the reason a "reasonable" test would have missed this.

Red check, reordering `Header().Set` after `WriteHeader` inside `SendJSONStatus`:

```
--- FAIL: TestSendJSONStatus/OK
--- FAIL: TestSendJSONStatus/Created
--- FAIL: TestSendJSONStatus/Accepted
--- FAIL: TestSendJSONKeepsTheJSONContentType
```

`golangci-lint` 0 issues. `postgres`'s `TestInTx`/`TestWithinTx*` fail locally for want of a database — identical on master, unrelated.

## Release and rollout

**Minor.** New exported symbol, no behaviour change for any existing caller (`SendJSON` still answers 200 + `application/json`), no signature change.

Sequencing from here:

1. Release golib with `SendJSONStatus`.
2. `service-template` and `service-narrative-engine` fix their 201 handlers — those are real defects, and I'll file one issue each.
3. `service-authentication` (12 sites) and `service-json-keys` (3) migrate off the deprecated symbol opportunistically; no defect, so no rush.
4. Remove `SendJSON` once all 26 sites are migrated — I'll open a tracking issue so the deprecation does not become permanent furniture.

⚠️ `service-narrative-engine` is being worked by another session, so I will file its issue but not touch the repo.
