### PR TITLE
fix(config): panic on a value that is set but does not parse

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -10,15 +10,11 @@ import (
 	"time"
 )
 
-// LoadEnv parses the raw environment value into T using parser, returning fallback when the value
-// is empty.
+// LoadEnv parses the raw environment value into T using parser.
 //
-// A value that is set but does not parse panics. Configuration is read at boot, from package-level
-// vars, so the panic lands before the service serves anything. Falling back instead would make a
-// typo indistinguishable from an unset variable, and the fallback is chosen for the second case:
-// OTEL=on parses as no bool at all and selects the preset that disables every exporter, and a
-// malformed origin list falls back to "*", widening CORS where the operator meant to narrow it.
-// Neither says anything, and the first disables the subsystem that would have.
+// An empty value yields fallback. A value that is set but does not parse panics, naming the value
+// and the type it could not become. Configuration is read at boot from package-level vars, so the
+// panic precedes any traffic.
 func LoadEnv[T any](value string, fallback T, parser func(string) (T, error)) T {
 	if value == "" {
 		return fallback
@@ -26,8 +22,6 @@ func LoadEnv[T any](value string, fallback T, parser func(string) (T, error)) T 
 
 	parsedValue, err := parser(value)
 	if err != nil {
-		// The variable's name is not in scope here, so the value and its target type are what
-		// point at the line to fix.
 		panic(fmt.Errorf("(LoadEnv) cannot parse %q as %T: %w", value, fallback, err))
 	}
 

--- a/config/env.go
+++ b/config/env.go
@@ -11,7 +11,14 @@ import (
 )
 
 // LoadEnv parses the raw environment value into T using parser, returning fallback when the value
-// is empty or the parser reports an error.
+// is empty.
+//
+// A value that is set but does not parse panics. Configuration is read at boot, from package-level
+// vars, so the panic lands before the service serves anything. Falling back instead would make a
+// typo indistinguishable from an unset variable, and the fallback is chosen for the second case:
+// OTEL=on parses as no bool at all and selects the preset that disables every exporter, and a
+// malformed origin list falls back to "*", widening CORS where the operator meant to narrow it.
+// Neither says anything, and the first disables the subsystem that would have.
 func LoadEnv[T any](value string, fallback T, parser func(string) (T, error)) T {
 	if value == "" {
 		return fallback
@@ -19,7 +26,9 @@ func LoadEnv[T any](value string, fallback T, parser func(string) (T, error)) T 
 
 	parsedValue, err := parser(value)
 	if err != nil {
-		return fallback
+		// The variable's name is not in scope here, so the value and its target type are what
+		// point at the line to fix.
+		panic(fmt.Errorf("(LoadEnv) cannot parse %q as %T: %w", value, fallback, err))
 	}
 
 	return parsedValue

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -14,6 +14,8 @@ func TestEnvStringParser(t *testing.T) {
 	t.Setenv("foo", "foo:value")
 
 	require.Equal(t, "foo:value", config.LoadEnv(os.Getenv("foo"), "foo:default", config.StringParser))
+	// bar is unset here, and StringParser cannot fail regardless — an absent variable still
+	// resolves to its fallback.
 	require.Equal(t, "bar:default", config.LoadEnv(os.Getenv("bar"), "bar:default", config.StringParser))
 }
 
@@ -22,7 +24,7 @@ func TestEnvInt64Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, int64(123), config.LoadEnv(os.Getenv("foo"), 321, config.Int64Parser))
-	require.Equal(t, int64(321), config.LoadEnv(os.Getenv("bar"), 321, config.Int64Parser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.Int64Parser) })
 	require.Equal(t, int64(321), config.LoadEnv(os.Getenv("qux"), 321, config.Int64Parser))
 }
 
@@ -31,7 +33,7 @@ func TestEnvInt32Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, int32(123), config.LoadEnv(os.Getenv("foo"), 321, config.Int32Parser))
-	require.Equal(t, int32(321), config.LoadEnv(os.Getenv("bar"), 321, config.Int32Parser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.Int32Parser) })
 	require.Equal(t, int32(321), config.LoadEnv(os.Getenv("qux"), 321, config.Int32Parser))
 }
 
@@ -40,7 +42,7 @@ func TestEnvInt16Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, int16(123), config.LoadEnv(os.Getenv("foo"), 321, config.Int16Parser))
-	require.Equal(t, int16(321), config.LoadEnv(os.Getenv("bar"), 321, config.Int16Parser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.Int16Parser) })
 	require.Equal(t, int16(321), config.LoadEnv(os.Getenv("qux"), 321, config.Int16Parser))
 }
 
@@ -49,7 +51,7 @@ func TestEnvInt8Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, int8(123), config.LoadEnv(os.Getenv("foo"), 64, config.Int8Parser))
-	require.Equal(t, int8(64), config.LoadEnv(os.Getenv("bar"), 64, config.Int8Parser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 64, config.Int8Parser) })
 	require.Equal(t, int8(64), config.LoadEnv(os.Getenv("qux"), 64, config.Int8Parser))
 }
 
@@ -58,7 +60,7 @@ func TestEnvIntParser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, 123, config.LoadEnv(os.Getenv("foo"), 321, config.IntParser))
-	require.Equal(t, 321, config.LoadEnv(os.Getenv("bar"), 321, config.IntParser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.IntParser) })
 	require.Equal(t, 321, config.LoadEnv(os.Getenv("qux"), 321, config.IntParser))
 }
 
@@ -67,7 +69,7 @@ func TestEnvUint64Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, uint64(123), config.LoadEnv(os.Getenv("foo"), 321, config.Uint64Parser))
-	require.Equal(t, uint64(321), config.LoadEnv(os.Getenv("bar"), 321, config.Uint64Parser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.Uint64Parser) })
 	require.Equal(t, uint64(321), config.LoadEnv(os.Getenv("qux"), 321, config.Uint64Parser))
 }
 
@@ -76,7 +78,7 @@ func TestEnvUint32Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, uint32(123), config.LoadEnv(os.Getenv("foo"), 321, config.Uint32Parser))
-	require.Equal(t, uint32(321), config.LoadEnv(os.Getenv("bar"), 321, config.Uint32Parser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.Uint32Parser) })
 	require.Equal(t, uint32(321), config.LoadEnv(os.Getenv("qux"), 321, config.Uint32Parser))
 }
 
@@ -85,7 +87,7 @@ func TestEnvUint16Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, uint16(123), config.LoadEnv(os.Getenv("foo"), 321, config.Uint16Parser))
-	require.Equal(t, uint16(321), config.LoadEnv(os.Getenv("bar"), 321, config.Uint16Parser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.Uint16Parser) })
 	require.Equal(t, uint16(321), config.LoadEnv(os.Getenv("qux"), 321, config.Uint16Parser))
 }
 
@@ -94,7 +96,7 @@ func TestEnvUint8Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, uint8(123), config.LoadEnv(os.Getenv("foo"), 64, config.Uint8Parser))
-	require.Equal(t, uint8(64), config.LoadEnv(os.Getenv("bar"), 64, config.Uint8Parser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 64, config.Uint8Parser) })
 	require.Equal(t, uint8(64), config.LoadEnv(os.Getenv("qux"), 64, config.Uint8Parser))
 }
 
@@ -103,7 +105,7 @@ func TestEnvUintParser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, uint(123), config.LoadEnv(os.Getenv("foo"), 321, config.UintParser))
-	require.Equal(t, uint(321), config.LoadEnv(os.Getenv("bar"), 321, config.UintParser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.UintParser) })
 	require.Equal(t, uint(321), config.LoadEnv(os.Getenv("qux"), 321, config.UintParser))
 }
 
@@ -112,7 +114,7 @@ func TestEnvBoolParser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.False(t, config.LoadEnv(os.Getenv("foo"), true, config.BoolParser))
-	require.True(t, config.LoadEnv(os.Getenv("bar"), true, config.BoolParser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), true, config.BoolParser) })
 	require.True(t, config.LoadEnv(os.Getenv("qux"), true, config.BoolParser))
 }
 
@@ -121,7 +123,7 @@ func TestEnvFloat64Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.InEpsilon(t, float64(123), config.LoadEnv(os.Getenv("foo"), 321, config.Float64Parser), 0.0001)
-	require.InEpsilon(t, float64(321), config.LoadEnv(os.Getenv("bar"), 321, config.Float64Parser), 0.0001)
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.Float64Parser) })
 	require.InEpsilon(t, float64(321), config.LoadEnv(os.Getenv("qux"), 321, config.Float64Parser), 0.0001)
 }
 
@@ -130,7 +132,7 @@ func TestEnvFloat32Parser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.InEpsilon(t, float32(123), config.LoadEnv(os.Getenv("foo"), 321, config.Float32Parser), 0.0001)
-	require.InEpsilon(t, float32(321), config.LoadEnv(os.Getenv("bar"), 321, config.Float32Parser), 0.0001)
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), 321, config.Float32Parser) })
 	require.InEpsilon(t, float32(321), config.LoadEnv(os.Getenv("qux"), 321, config.Float32Parser), 0.0001)
 }
 
@@ -139,7 +141,7 @@ func TestEnvDurationParser(t *testing.T) {
 	t.Setenv("bar", "bar:value")
 
 	require.Equal(t, 5*time.Second, config.LoadEnv(os.Getenv("foo"), time.Second, config.DurationParser))
-	require.Equal(t, time.Second, config.LoadEnv(os.Getenv("bar"), time.Second, config.DurationParser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), time.Second, config.DurationParser) })
 	require.Equal(t, time.Second, config.LoadEnv(os.Getenv("qux"), time.Second, config.DurationParser))
 }
 
@@ -151,7 +153,7 @@ func TestEnvTimeParser(t *testing.T) {
 	custom := time.Date(2020, 1, 2, 15, 4, 5, 0, time.UTC)
 
 	require.Equal(t, custom, config.LoadEnv(os.Getenv("foo"), now, config.TimeParser))
-	require.Equal(t, now, config.LoadEnv(os.Getenv("bar"), now, config.TimeParser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), now, config.TimeParser) })
 	require.Equal(t, now, config.LoadEnv(os.Getenv("qux"), now, config.TimeParser))
 }
 
@@ -163,7 +165,7 @@ func TestEnvJSONMapParser(t *testing.T) {
 	custom := map[string]any{"key": "super-value"}
 
 	require.Equal(t, custom, config.LoadEnv(os.Getenv("foo"), basic, config.JSONMapParser))
-	require.Equal(t, basic, config.LoadEnv(os.Getenv("bar"), basic, config.JSONMapParser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), basic, config.JSONMapParser) })
 	require.Equal(t, basic, config.LoadEnv(os.Getenv("qux"), basic, config.JSONMapParser))
 }
 
@@ -175,7 +177,7 @@ func TestEnvJSONSliceParser(t *testing.T) {
 	custom := []any{map[string]any{"key": "super-value"}}
 
 	require.Equal(t, custom, config.LoadEnv(os.Getenv("foo"), basic, config.JSONSliceParser))
-	require.Equal(t, basic, config.LoadEnv(os.Getenv("bar"), basic, config.JSONSliceParser))
+	require.Panics(t, func() { _ = config.LoadEnv(os.Getenv("bar"), basic, config.JSONSliceParser) })
 	require.Equal(t, basic, config.LoadEnv(os.Getenv("qux"), basic, config.JSONSliceParser))
 }
 
@@ -186,6 +188,7 @@ func TestEnvStringSliceParser(t *testing.T) {
 	custom := []string{"foo", "bar", "baz"}
 
 	require.Equal(t, custom, config.LoadEnv(os.Getenv("foo"), basic, config.SliceParser(config.StringParser)))
+	// bar is unset here, so the fallback stands.
 	require.Equal(t, basic, config.LoadEnv(os.Getenv("bar"), basic, config.SliceParser(config.StringParser)))
 }
 
@@ -197,9 +200,44 @@ func TestEnvEnumParser(t *testing.T) {
 		"bar",
 		config.LoadEnv(os.Getenv("foo"), "invalid", config.EnumParser(config.StringParser, "foo", "bar")),
 	)
-	require.Equal(
-		t,
-		"invalid",
-		config.LoadEnv(os.Getenv("foo"), "invalid", config.EnumParser(config.StringParser, "foo", "baz")),
-	)
+	// A value outside the allow list is set-but-wrong, which is exactly what must not resolve to
+	// the fallback: the operator named something, and it is not one of the choices.
+	require.Panics(t, func() {
+		_ = config.LoadEnv(os.Getenv("foo"), "invalid", config.EnumParser(config.StringParser, "foo", "baz"))
+	})
+}
+
+// LoadEnv never sees the variable's name, so the message has to point at the line to fix with what
+// it does have: the offending value, the type it could not become, and the parser's own complaint.
+func TestLoadEnvPanicNamesTheValueAndType(t *testing.T) {
+	t.Setenv("foo", "on")
+
+	// The live instance behind this: OTEL=on parses as no bool at all, and the fallback selects the
+	// preset that turns every exporter off — so the subsystem that would report the mistake is the
+	// one the mistake disables.
+	err := requirePanicError(t, func() {
+		_ = config.LoadEnv(os.Getenv("foo"), false, config.BoolParser)
+	})
+
+	require.ErrorContains(t, err, `"on"`)
+	require.ErrorContains(t, err, "bool")
+	require.ErrorContains(t, err, "invalid syntax", "the parser's own error must survive")
+}
+
+func requirePanicError(t *testing.T, fn func()) (err error) {
+	t.Helper()
+
+	defer func() {
+		recovered := recover()
+		require.NotNil(t, recovered, "expected a panic")
+
+		var ok bool
+
+		err, ok = recovered.(error)
+		require.True(t, ok, "expected the panic to carry an error, got %T", recovered)
+	}()
+
+	fn()
+
+	return nil
 }

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -14,8 +14,7 @@ func TestEnvStringParser(t *testing.T) {
 	t.Setenv("foo", "foo:value")
 
 	require.Equal(t, "foo:value", config.LoadEnv(os.Getenv("foo"), "foo:default", config.StringParser))
-	// bar is unset here, and StringParser cannot fail regardless — an absent variable still
-	// resolves to its fallback.
+	// bar is unset, and StringParser cannot fail regardless.
 	require.Equal(t, "bar:default", config.LoadEnv(os.Getenv("bar"), "bar:default", config.StringParser))
 }
 
@@ -200,21 +199,19 @@ func TestEnvEnumParser(t *testing.T) {
 		"bar",
 		config.LoadEnv(os.Getenv("foo"), "invalid", config.EnumParser(config.StringParser, "foo", "bar")),
 	)
-	// A value outside the allow list is set-but-wrong, which is exactly what must not resolve to
-	// the fallback: the operator named something, and it is not one of the choices.
+	// A value outside the allow list is set-but-wrong, not absent.
 	require.Panics(t, func() {
 		_ = config.LoadEnv(os.Getenv("foo"), "invalid", config.EnumParser(config.StringParser, "foo", "baz"))
 	})
 }
 
-// LoadEnv never sees the variable's name, so the message has to point at the line to fix with what
-// it does have: the offending value, the type it could not become, and the parser's own complaint.
+// The panic carries the offending value, the type it could not become, and the parser's own error.
+// LoadEnv never sees the variable's name, so those three are what locate the line to fix.
 func TestLoadEnvPanicNamesTheValueAndType(t *testing.T) {
 	t.Setenv("foo", "on")
 
-	// The live instance behind this: OTEL=on parses as no bool at all, and the fallback selects the
-	// preset that turns every exporter off — so the subsystem that would report the mistake is the
-	// one the mistake disables.
+	// OTEL=on is the live instance: no bool strconv recognises, and the fallback selects the preset
+	// that turns every exporter off.
 	err := requirePanicError(t, func() {
 		_ = config.LoadEnv(os.Getenv("foo"), false, config.BoolParser)
 	})


### PR DESCRIPTION
Item **1** of #372, per your ruling:

> LoadEnv is a commodity, made to load things fast and more importantly, without wrapping a function (which error handling needs). So if anything, and since it only runs on boot, use panic to distinguish malformed values, rather than an error return.

## The defect

`LoadEnv` returned the fallback both for an **unset** variable and for one whose value the parser **rejected**. The fallback is chosen for the first case, which makes it the wrong answer for the second.

Two live instances:

- **`OTEL=on`** — not a bool `strconv` recognises (nor `yes`, nor `enabled`). Resolved to `false`, selecting `otelpresets.Disabled{}`: all trace and log export off. Self-concealing — the subsystem that would carry the evidence is the one being disabled.
- **A malformed `REST_CORS_ALLOWED_ORIGINS`** — falls back to `[]string{"*"}`, **widening** CORS to every origin where the operator meant to narrow it. Same default in all services.

All five consuming services route every configuration value through this function.

## The fix

A set-but-unparseable value panics. The panic names the value, the type it could not become, and the parser's own complaint:

```
panic: (LoadEnv) cannot parse "on" as bool: strconv.ParseBool: parsing "on": invalid syntax
```

The variable's *name* is not in scope — `LoadEnv` receives the value, not the key — so those three are what point at the line to fix. Adding a name parameter would have touched every call site in five repos for a message improvement; the type does most of that work.

## The tests were the specification

Nineteen assertions across the parser tests pinned *"malformed yields the default, silently"*. Eighteen are now panics; the nineteenth covers an **unset** variable, which still resolves to its fallback and must keep doing so.

**The `EnumParser` case is the one worth reviewing.** It escaped my mechanical sweep because it reads `os.Getenv("foo")`, not `"bar"` — and it is the sharpest form of this defect:

```go
// before: a value outside the allow list silently became the default
require.Equal(t, "invalid",
    config.LoadEnv(os.Getenv("foo"), "invalid", config.EnumParser(config.StringParser, "foo", "baz")))
```

The operator named something, it was not one of the choices, and the service ran on the default.

## Verification against a real service

Not just unit tests — `service-template`'s REST binary, with a `replace` onto this branch:

| environment | result |
|---|---|
| the compose environment (`SMTP_FORCE_UNENCRYPTED=true`, `SERVICE_JSON_KEYS_PORT=8080`, …) | starts, **0** `LoadEnv` panics |
| `OTEL=on` | panics with the message above |

I also checked what could newly break at boot:

- **No service uses `EnumParser`** — the newly strict path has no live caller.
- Every bool the compose files set (`SMTP_FORCE_UNENCRYPTED: true`) parses.
- Everything else is unset, so it takes the fallback exactly as before.
- **`a-novel/agora-infra` carries no service environment at all** (terraform, docs, scripts), so there is no deployed configuration this could surprise.

## Follow-ups this does not do

- **The CORS default itself.** `CorsAllowedOriginsDefault = []string{"*"}` is service-side, and falling back to `*` is the wrong direction even for an *unset* variable. The panic removes the malformed path; the unset path is a separate call, and yours to make.
- **`service-jobs`** turned up as a fifth consumer of `LoadEnv` while I was checking blast radius. Nothing to do here — noting it because the issue said four.

Items 2 (logging doc) and 3 (response-writer capture) of #372 follow separately.
