### PR TITLE
docs(migrations): write the v0.26.0 note

### DIFF
--- a/docs/migrations/v0.26.0.md
+++ b/docs/migrations/v0.26.0.md
@@ -1,0 +1,90 @@
+# Migrating to v0.26.0
+
+Two changes, one of which can stop a service from starting. Read the first section before you deploy
+this; the second is a deprecation you can take at your own pace.
+
+## `config.LoadEnv` panics on a value it cannot parse
+
+`LoadEnv` used to return the fallback in two different situations: the variable was unset, or it was
+set to something the parser rejected. It now returns the fallback only for the first, and panics for
+the second.
+
+```
+panic: (LoadEnv) cannot parse "on" as bool: strconv.ParseBool: parsing "on": invalid syntax
+```
+
+### Do I need to act?
+
+**Check your environment before deploying.** Any variable currently set to a value its parser
+rejects is, today, silently running on the default. After this release the service panics at boot
+instead.
+
+Configuration is read from package-level vars, so the panic happens during package initialisation —
+before the listener opens. A service that starts, starts correctly; there is no partial state to
+clean up.
+
+The values worth checking first, because they are the ones whose fallback is actively harmful:
+
+| Variable                    | A value like                | Was silently                                    |
+| --------------------------- | --------------------------- | ----------------------------------------------- |
+| `OTEL`                      | `on`, `yes`, `enabled`      | `false` — every trace and log exporter disabled |
+| `REST_CORS_ALLOWED_ORIGINS` | `" "`, a stray trailing `,` | `["*"]` — CORS widened to every origin          |
+| any `*_TIMEOUT`, `*_TTL`    | `30` (no unit)              | the compiled-in default                         |
+| any `*_PORT`, `*_MAX_*`     | `8080 ` with whitespace     | the compiled-in default                         |
+
+`OTEL` is the one to check twice: the fallback disables the subsystem that would have reported the
+mistake, so there is no signal anywhere that it took effect.
+
+`strconv.ParseBool` accepts `1 t T TRUE true True 0 f F FALSE false False` and nothing else.
+
+### Sweeping an environment
+
+```bash
+# Values that parse as a bool; anything else in this list needs correcting.
+env | grep -E '^(OTEL|.*_ENABLED|.*_ALLOW_CREDENTIALS|SMTP_FORCE_UNENCRYPTED)='
+```
+
+An empty value is still an empty value — `OTEL=` takes the fallback exactly as before. Only a
+non-empty, unparseable value panics.
+
+### If you want the old behaviour for one value
+
+There is no lenient variant, deliberately. If a value is genuinely optional, leave it unset; that is
+what the fallback is for. If it is set, it is meant, and a value that cannot be honoured is a
+configuration error rather than a preference.
+
+## `httpf.SendJSON` is deprecated
+
+`httpf.SendJSONStatus` takes the status code:
+
+```go
+// before
+w.WriteHeader(http.StatusCreated)
+httpf.SendJSON(ctx, w, span, body)
+
+// after
+httpf.SendJSONStatus(ctx, w, span, http.StatusCreated, body)
+```
+
+### Do I need to act?
+
+**Yes, if any handler sets a status before calling `SendJSON`.** That handler is answering
+`text/plain` today, whatever its OpenAPI spec says: `net/http` freezes the outbound header set at
+`WriteHeader`, so the `Content-Type` `SendJSON` sets afterwards is discarded.
+
+Those call sites now also log `superfluous response.WriteHeader call` on every request, because
+`SendJSON` writes the status itself. That is intentional — the mistake was silent before, and the log
+stops once the call site moves to `SendJSONStatus`.
+
+**No, for a handler that never calls `WriteHeader`.** `SendJSON` still answers `200` with
+`application/json`. Migrate when convenient, passing `http.StatusOK`.
+
+`SendJSON` will be removed once every consumer has migrated. Its signature cannot express a status
+other than 200 without reintroducing the defect, which is why it is going rather than being kept as
+a shorthand.
+
+### Finding the call sites
+
+```bash
+grep -rn 'SendJSON(' --include='*.go' . | grep -v 'SendJSONStatus'
+```


### PR DESCRIPTION
Blocks the v0.26.0 tag. `LoadEnv`'s panic changes **boot** behaviour for five services, so the note has to ship *with* the release, not after someone hits it.

## What it covers

**`config.LoadEnv` panics** (#395) — the section leads with "check your environment before deploying", and tables the variables whose fallback is actively harmful:

| Variable | A value like | Was silently |
|---|---|---|
| `OTEL` | `on`, `yes`, `enabled` | `false` — every exporter disabled |
| `REST_CORS_ALLOWED_ORIGINS` | `" "`, a stray trailing `,` | `["*"]` — CORS widened to every origin |
| any `*_TIMEOUT` / `*_TTL` | `30` (no unit) | the compiled-in default |

`OTEL` is flagged to check twice, because its fallback disables the subsystem that would have reported the mistake — there is no signal anywhere that it took effect.

It also states the two things an operator will actually ask: an **empty** value still takes the fallback (only a non-empty unparseable one panics), and there is deliberately **no lenient variant** — if a value is optional, leave it unset; if it is set, it is meant.

**`httpf.SendJSON` deprecated** (#393) — what to change, what can wait, and why the shorthand is not being kept. Including that migrated-pending call sites now log `superfluous response.WriteHeader call` on every request, which is intentional and stops on migration.

## Verified rather than asserted

The claims in the `LoadEnv` section come from the checks in #395, not from reading the code: `service-template`'s REST binary starts clean under the compose environment and panics under `OTEL=on`, no service uses `EnumParser`, and `agora-infra` carries no service environment.

## After this merges

`v0.26.0` — **minor**, on `feat(httpf)`. Unreleased since `v0.25.1`: the two changes above plus dependency and CI chores.

That release unblocks three issues currently waiting on `SendJSONStatus`:

- a-novel/service-template#426 and a-novel/service-narrative-engine#456 — the 201 handlers answering `text/plain`
- #394 — the `SendJSON` removal tracker

## Not in this release

The rest of #372 — the logging doc ruling, the response-writer capture fix, and three smaller items — comes after. I chose not to hold the tag for them: bundling a **breaking boot change** with a memory fix and a doc fix makes it much harder to attribute a boot failure if one shows up. Two changes and a migration note is a release someone can reason about.
