### PR TITLE
fix(otel): forward the optional writer interfaces and keep only failing bodies

### DIFF
--- a/otel/utils/http.go
+++ b/otel/utils/http.go
@@ -1,12 +1,32 @@
 package utils
 
 import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
 )
 
-// CaptureHTTPResponseWriter wraps an http.ResponseWriter and records the status
-// code, byte count, and full body as the handler writes them, so middleware can
-// inspect the response after the handler returns.
+// ErrNotHijackable is returned by Hijack when the wrapped writer does not support
+// hijacking, as on HTTP/2.
+var ErrNotHijackable = errors.New("the underlying ResponseWriter does not support hijacking")
+
+// captureBodyFrom is the lowest status whose body is kept. Both HTTP logging presets
+// read Response() only to report a failure, so a successful response has nothing to keep
+// it for.
+const captureBodyFrom = http.StatusBadRequest
+
+// CaptureHTTPResponseWriter wraps an http.ResponseWriter and records the status code and
+// byte count as the handler writes them, so middleware can report them after the handler
+// returns. The body is recorded only for a status of 400 or above.
+//
+// It forwards the optional interfaces a handler reaches for — [http.Flusher],
+// [http.Hijacker], [io.ReaderFrom] — and exposes Unwrap for [http.ResponseController].
+// Embedding the interface alone promotes only Header, Write and WriteHeader, and a
+// handler's own `w.(http.Flusher)` check would then take its no-flush branch against a
+// writer that can in fact flush.
 type CaptureHTTPResponseWriter struct {
 	http.ResponseWriter
 
@@ -14,6 +34,13 @@ type CaptureHTTPResponseWriter struct {
 	size     int64
 	response []byte
 }
+
+// Compile-time proof that the optional interfaces survive the wrap.
+var (
+	_ http.Flusher  = (*CaptureHTTPResponseWriter)(nil)
+	_ http.Hijacker = (*CaptureHTTPResponseWriter)(nil)
+	_ io.ReaderFrom = (*CaptureHTTPResponseWriter)(nil)
+)
 
 func (w *CaptureHTTPResponseWriter) WriteHeader(statusCode int) {
 	w.status = statusCode
@@ -27,9 +54,83 @@ func (w *CaptureHTTPResponseWriter) Write(b []byte) (int, error) {
 	}
 
 	w.size += int64(n)
-	w.response = append(w.response, b...)
+
+	// A handler that writes without calling WriteHeader leaves status at 0, which is an
+	// implicit 200 and so not captured.
+	if w.status >= captureBodyFrom {
+		w.response = append(w.response, b[:n]...)
+	}
 
 	return n, nil
+}
+
+// Unwrap returns the wrapped writer, which is how [http.ResponseController] reaches
+// Flush, Hijack and the deadline setters through a chain of middleware.
+func (w *CaptureHTTPResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+// Flush forwards to the wrapped writer when it can flush, and does nothing otherwise —
+// the same outcome a handler's own capability check would reach.
+func (w *CaptureHTTPResponseWriter) Flush() {
+	flusher, ok := w.ResponseWriter.(http.Flusher)
+	if !ok {
+		return
+	}
+
+	flusher.Flush()
+}
+
+// Hijack forwards to the wrapped writer, and reports [ErrNotHijackable] when it does not
+// support hijacking.
+func (w *CaptureHTTPResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, ErrNotHijackable
+	}
+
+	conn, buf, err := hijacker.Hijack()
+	if err != nil {
+		return nil, nil, fmt.Errorf("(CaptureHTTPResponseWriter.Hijack) %w", err)
+	}
+
+	return conn, buf, nil
+}
+
+// ReadFrom forwards to the wrapped writer's own ReadFrom when it has one, so a file
+// served this way keeps whatever fast path the platform offers. Otherwise the data is
+// copied through Write.
+//
+// The forwarding path streams past this wrapper, so a body sent through it is counted
+// but not captured. It carries a successful response; the failing statuses whose body
+// the presets read are written as bytes.
+func (w *CaptureHTTPResponseWriter) ReadFrom(src io.Reader) (int64, error) {
+	readerFrom, ok := w.ResponseWriter.(io.ReaderFrom)
+	if !ok {
+		// writerOnly hides this type's own ReadFrom, so io.Copy cannot select it and
+		// recurse.
+		written, err := io.Copy(writerOnly{w}, src)
+		if err != nil {
+			return written, fmt.Errorf("(CaptureHTTPResponseWriter.ReadFrom) %w", err)
+		}
+
+		return written, nil
+	}
+
+	written, err := readerFrom.ReadFrom(src)
+	w.size += written
+
+	if err != nil {
+		return written, fmt.Errorf("(CaptureHTTPResponseWriter.ReadFrom) %w", err)
+	}
+
+	return written, nil
+}
+
+// writerOnly exposes only Write, so io.Copy falls back to it rather than finding a
+// ReadFrom and calling back into its caller.
+type writerOnly struct {
+	io.Writer
 }
 
 // Status returns the captured status code, defaulting to 200 when the handler
@@ -46,6 +147,7 @@ func (w *CaptureHTTPResponseWriter) Size() int64 {
 	return w.size
 }
 
+// Response returns the recorded body. It is populated only for a status of 400 or above.
 func (w *CaptureHTTPResponseWriter) Response() []byte {
 	return w.response
 }

--- a/otel/utils/http_test.go
+++ b/otel/utils/http_test.go
@@ -1,0 +1,194 @@
+package utils_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/otel/utils"
+)
+
+// The wrapper is the innermost middleware in every service, so it is the writer every
+// handler receives. What it drops, every handler loses.
+
+func TestCaptureKeepsTheBodyOnlyForAFailure(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+
+		status int
+		// writeHeader reflects a handler that writes without calling WriteHeader, where
+		// net/http sends an implicit 200.
+		writeHeader bool
+
+		expectStatus int
+		expectBody   string
+	}{
+		{
+			name:         "ImplicitOK",
+			writeHeader:  false,
+			expectStatus: http.StatusOK,
+			expectBody:   "",
+		},
+		{
+			name:         "ExplicitOK",
+			status:       http.StatusOK,
+			writeHeader:  true,
+			expectStatus: http.StatusOK,
+			expectBody:   "",
+		},
+		{
+			name:         "Created",
+			status:       http.StatusCreated,
+			writeHeader:  true,
+			expectStatus: http.StatusCreated,
+			expectBody:   "",
+		},
+		{
+			// The local preset reports a body from 400 up, not 500 up.
+			name:         "BadRequest",
+			status:       http.StatusBadRequest,
+			writeHeader:  true,
+			expectStatus: http.StatusBadRequest,
+			expectBody:   "payload",
+		},
+		{
+			name:         "InternalServerError",
+			status:       http.StatusInternalServerError,
+			writeHeader:  true,
+			expectStatus: http.StatusInternalServerError,
+			expectBody:   "payload",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			wrapped := &utils.CaptureHTTPResponseWriter{ResponseWriter: httptest.NewRecorder()}
+
+			if testCase.writeHeader {
+				wrapped.WriteHeader(testCase.status)
+			}
+
+			n, err := wrapped.Write([]byte("payload"))
+			require.NoError(t, err)
+			require.Equal(t, len("payload"), n)
+
+			require.Equal(t, testCase.expectStatus, wrapped.Status())
+			require.Equal(t, testCase.expectBody, string(wrapped.Response()))
+
+			// The size is counted whether or not the body is kept, since it is reported
+			// for every request.
+			require.Equal(t, int64(len("payload")), wrapped.Size())
+		})
+	}
+}
+
+// flushRecorder reports whether Flush reached the writer underneath the wrapper.
+type flushRecorder struct {
+	http.ResponseWriter
+
+	flushed bool
+}
+
+func (w *flushRecorder) Flush() { w.flushed = true }
+
+func TestCaptureForwardsFlush(t *testing.T) {
+	t.Parallel()
+
+	// The idiomatic capability check a streaming handler makes. Against a wrapper that
+	// only embeds the interface it yields false, and the handler buffers what it meant
+	// to stream.
+	underlying := &flushRecorder{ResponseWriter: httptest.NewRecorder()}
+	wrapped := &utils.CaptureHTTPResponseWriter{ResponseWriter: underlying}
+
+	flusher, ok := any(wrapped).(http.Flusher)
+	require.True(t, ok, "a handler's own http.Flusher assertion must succeed")
+
+	flusher.Flush()
+	require.True(t, underlying.flushed, "Flush must reach the writer underneath")
+}
+
+func TestCaptureFlushIsSafeWithoutSupport(t *testing.T) {
+	t.Parallel()
+
+	// httptest.NewRecorder does implement Flusher, so a writer that does not needs to be
+	// built by hand.
+	wrapped := &utils.CaptureHTTPResponseWriter{ResponseWriter: writeOnlyResponseWriter{}}
+
+	require.NotPanics(t, wrapped.Flush)
+}
+
+func TestCaptureHijackReportsAWriterThatCannot(t *testing.T) {
+	t.Parallel()
+
+	wrapped := &utils.CaptureHTTPResponseWriter{ResponseWriter: httptest.NewRecorder()}
+
+	_, _, err := wrapped.Hijack()
+	require.ErrorIs(t, err, utils.ErrNotHijackable)
+}
+
+func TestCaptureUnwrapReachesTheWrappedWriter(t *testing.T) {
+	t.Parallel()
+
+	// http.ResponseController walks Unwrap to find Flush, so a chain of middleware stays
+	// transparent to it.
+	underlying := &flushRecorder{ResponseWriter: httptest.NewRecorder()}
+	wrapped := &utils.CaptureHTTPResponseWriter{ResponseWriter: underlying}
+
+	require.NoError(t, http.NewResponseController(wrapped).Flush())
+	require.True(t, underlying.flushed)
+}
+
+func TestCaptureReadFromCountsWithoutAWrappedReaderFrom(t *testing.T) {
+	t.Parallel()
+
+	// The fallback copies through Write, so the size stays accurate and the copy does not
+	// recurse into ReadFrom.
+	recorder := httptest.NewRecorder()
+	wrapped := &utils.CaptureHTTPResponseWriter{ResponseWriter: recorder}
+
+	written, err := wrapped.ReadFrom(strings.NewReader("streamed"))
+	require.NoError(t, err)
+	require.Equal(t, int64(len("streamed")), written)
+	require.Equal(t, int64(len("streamed")), wrapped.Size())
+	require.Equal(t, "streamed", recorder.Body.String())
+}
+
+func TestCaptureReadFromForwardsWhenSupported(t *testing.T) {
+	t.Parallel()
+
+	underlying := &readFromRecorder{ResponseWriter: httptest.NewRecorder()}
+	wrapped := &utils.CaptureHTTPResponseWriter{ResponseWriter: underlying}
+
+	written, err := wrapped.ReadFrom(strings.NewReader("streamed"))
+	require.NoError(t, err)
+	require.Equal(t, int64(len("streamed")), written)
+	require.True(t, underlying.used, "the wrapped writer's own ReadFrom must be preferred")
+	require.Equal(t, int64(len("streamed")), wrapped.Size())
+}
+
+type readFromRecorder struct {
+	http.ResponseWriter
+
+	used bool
+}
+
+func (w *readFromRecorder) ReadFrom(src io.Reader) (int64, error) {
+	w.used = true
+
+	return io.Copy(w.ResponseWriter, src)
+}
+
+// writeOnlyResponseWriter implements the interface and nothing beyond it.
+type writeOnlyResponseWriter struct{}
+
+func (writeOnlyResponseWriter) Header() http.Header         { return http.Header{} }
+func (writeOnlyResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (writeOnlyResponseWriter) WriteHeader(int)             {}


### PR DESCRIPTION
Item **3** of #372, on your "agree with your fix".

## Two defects in one wrapper

`CaptureHTTPResponseWriter` embeds the `http.ResponseWriter` **interface**, which promotes `Header`, `Write` and `WriteHeader` and nothing else. `http.Flusher`, `http.Hijacker` and `io.ReaderFrom` are silently dropped.

It is installed unconditionally by both HTTP logging presets as the **innermost** middleware, so it is the writer every route handler in every service receives.

The defensive idiom fails by design here, with no panic and no log:

```go
flusher, ok := w.(http.Flusher)   // ok == false, against a writer that can flush
if ok { flusher.Flush() }         // never taken
```

Separately, **every** response body was retained in full — `w.response = append(w.response, b...)` — while `Response()` is read only to report a failure. A 100-item JSON list was duplicated in the heap on every request, for data nothing would look at.

## One correction to the issue

It says `Response()` is read "only on `status >= 500`". That is true of the **gcloud** preset; the **local** preset (`http.local.go:48-52`) reads it for **4xx as well**. So capture starts at `400`, not `500` — cutting it at 500 would have emptied 4xx logs locally.

## The fix

`Flush`, `Hijack` and `ReadFrom` forward to the wrapped writer when it supports them, plus `Unwrap` so `http.ResponseController` (Go 1.20+) reaches through the chain. Compile-time assertions pin all three, so a future edit that drops one fails the build rather than the handler.

Two details worth a look:

- **`Hijack` returns `ErrNotHijackable`** rather than a nil conn when the wrapped writer cannot hijack — that is the HTTP/2 case, and a nil conn with a nil error would be the same class of silent failure.
- **`ReadFrom` forwards when it can**, so file serving keeps its platform fast path, and otherwise copies through `Write` via a `writerOnly` shim so `io.Copy` cannot re-select `ReadFrom` and recurse. The forwarding path streams past the wrapper, so its bytes are counted but not captured — documented, and it only carries successful responses.

## Where these combine

The streaming handler this milestone is waiting on: `ok == false`, so it buffers what it meant to stream **and** grows `w.response` by every chunk, for a 200 nobody reads. A narrative engine streaming model output is the obvious next handler.

## Verification

`otel/utils` had no test file, which is the whole story of how this survived.

Red check against the previous writer:

```
--- FAIL: TestCaptureForwardsFlush
--- FAIL: TestCaptureUnwrapReachesTheWrappedWriter
--- FAIL: TestCaptureKeepsTheBodyOnlyForAFailure   (ImplicitOK, ExplicitOK, Created)
```

The other four cannot compile against it — the methods are absent.

Worth flagging: **my first red check reported no failures at all**, because the edit that was meant to revert the source silently didn't apply and the grep came back clean. I rebuilt it by hand and checked the raw output. A green red-check is exactly the shape this milestone exists to distrust, and I nearly filed it as evidence.

The body table covers the boundary properly: implicit 200 (handler writes without `WriteHeader`, so `status` stays 0), explicit 200, 201, 400, 500.

`golangci-lint` 0 issues.

## Remaining in #372

Item 2 — the logging doc, per your ruling that the two presets' behaviours are intended — plus the three "also worth a look" items: the `*bun.DB` leak on a failed `Ping`, the discarded `tp.Shutdown`/`lp.Shutdown` errors in the sentry preset, and the test helpers that never drop their schema.
