### PR TITLE
fix(logging): render a message with no fields as written, and document both presets

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -7,8 +7,17 @@ package logging
 import "context"
 
 // Log is a leveled, context-aware logger. The context carries the request-scoped
-// trace information an implementation attaches to each entry, and fields hold any
-// extra data to record alongside the message.
+// trace information an implementation attaches to each entry.
+//
+// How fields are rendered belongs to the implementation, and the two presets differ
+// because their destinations do. LogGcloud hands them to slog, where each becomes a
+// structured attribute a log explorer can filter on. LogLocal renders msg as a format
+// string with fields as its operands, which is what reads as a line in a terminal.
+//
+// A call that passes fields therefore renders differently under each. Neither drops
+// data — a field with no verb to land on is appended, a verb with no field is marked
+// in place — but a caller wanting one exact line should format it into msg and pass no
+// fields. With no fields the two agree.
 type Log interface {
 	// Info records a routine event.
 	Info(ctx context.Context, msg string, fields ...any)

--- a/logging/presets/logging.local.go
+++ b/logging/presets/logging.local.go
@@ -39,5 +39,14 @@ func (logger *LogLocal) log(level LogLevel, msg string, fields ...any) {
 		lstyle = lstyle.Foreground(LipColorError)
 	}
 
-	_, _ = lipgloss.Fprint(logger.Out, lstyle.Render(fmt.Sprintf(msg, fields...))+"\n")
+	// With no operands there is nothing to format, and msg goes out as written. Running it
+	// through Sprintf would rewrite any % it contains — an error text reading "50% done"
+	// becomes "50%!(NOVERB)", losing the detail at the point the log exists to carry it.
+	// httpf.HandleError reaches here with the error text and no fields.
+	rendered := msg
+	if len(fields) > 0 {
+		rendered = fmt.Sprintf(msg, fields...)
+	}
+
+	_, _ = lipgloss.Fprint(logger.Out, lstyle.Render(rendered)+"\n")
 }

--- a/logging/presets/logging.local_test.go
+++ b/logging/presets/logging.local_test.go
@@ -1,0 +1,85 @@
+package loggingpresets_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	loggingpresets "github.com/a-novel-kit/golib/logging/presets"
+)
+
+func rendered(t *testing.T, msg string, fields []any) string {
+	t.Helper()
+
+	out := &bytes.Buffer{}
+	logger := &loggingpresets.LogLocal{Out: out}
+
+	logger.Err(t.Context(), msg, fields...)
+
+	// The severity colour arrives as ANSI escapes around the text.
+	return strings.TrimSpace(out.String())
+}
+
+// A message with no operands goes out as written. Passing it through Sprintf would
+// rewrite any % it contains, and the path that reaches here with none —
+// httpf.HandleError, with an error text — is the one whose detail matters most.
+func TestLogLocalDoesNotFormatWithoutFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+
+		msg string
+	}{
+		{
+			name: "PercentSign",
+			msg:  "disk usage at 95% on /var",
+		},
+		{
+			name: "VerbLikeSequence",
+			msg:  `parse "%s" failed`,
+		},
+		{
+			name: "TrailingPercent",
+			msg:  "progress: 100%",
+		},
+		{
+			name: "Plain",
+			msg:  "nothing special here",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := rendered(t, testCase.msg, nil)
+
+			require.Contains(t, got, testCase.msg)
+			require.NotContains(t, got, "%!", "the message must not be rewritten by a format pass")
+		})
+	}
+}
+
+// With operands, LogLocal renders msg as a format string. That is the local
+// convention, and the doc on logging.Log says so.
+func TestLogLocalFormatsWithFields(t *testing.T) {
+	t.Parallel()
+
+	got := rendered(t, "took %s for %d items", []any{"1.2s", 42})
+
+	require.Contains(t, got, "took 1.2s for 42 items")
+}
+
+// A field with no verb to land on is appended rather than dropped, which is what
+// makes the divergence between the two presets lossless.
+func TestLogLocalKeepsAFieldWithNoVerb(t *testing.T) {
+	t.Parallel()
+
+	got := rendered(t, "item rejected", []any{"credential-42"})
+
+	require.Contains(t, got, "item rejected")
+	require.Contains(t, got, "credential-42")
+}


### PR DESCRIPTION
Item **2** of #372, on your ruling:

> Logs behaviors are intended (they work on strictly different environments under their own constraints) -> fix the doc.

## The doc half

`logging.Log` documented fields as *"any extra data to record alongside the message"*, which describes `LogGcloud` and not `LogLocal`. Half the implementations contradicted the interface they satisfy.

The doc now states both conventions and that a caller wanting one exact line should format into `msg` and pass no fields. No code changed on that half.

## The half that is a bug regardless

`LogLocal` ran **every** message through `Sprintf`, including those with no fields at all. Any `%` in the text was then read as a verb:

```
"disk usage at 95% on /var"  ->  "disk usage at 95%!o(MISSING)n /var"
"progress: 100%"             ->  "progress: 100%!(NOVERB)"
`parse "%s" failed`          ->  `parse "%!s(MISSING)" failed`
```

**The first is the one to look at.** `% o` is consumed as a verb, taking the space and the `o` with it — `95% on` becomes `95%!o(MISSING)n`. The text is corrupted *mid-word*, not merely annotated. I had described this in the issue as noise appended to the line; it is worse than that, and the red check is what showed me.

`httpf.HandleError` reaches this path with the error text and no fields (`httpf/error.go:47`), so the corruption lands precisely on the diagnostic detail a failed request exists to report.

With no operands there is nothing to format, so `msg` now goes out as written. That is consistent with the printf convention rather than an exception to it.

## Why nothing caught it

`fmt.Sprintf` never errors — it embeds its complaint in the output and returns a string — and `LogLocal.log` discards the writer's return.

**And `go vet`'s printf checker does not reach the call site.** It flagged my *test* helper immediately (`non-constant format string`, `call has arguments but no formatting directives`) but stays silent on `HandleError`'s `logger.Err(ctx, err.Error())`. The tooling that exists for exactly this class had no purchase on the one call that needed it.

`logging` and `logging/presets` had no test files.

Red check:

```
--- FAIL: TestLogLocalDoesNotFormatWithoutFields/PercentSign
      "disk usage at 95%!o(MISSING)n /var" does not contain "disk usage at 95% on /var"
--- FAIL: TestLogLocalDoesNotFormatWithoutFields/TrailingPercent
      "progress: 100%!(NOVERB)" should not contain "%!"
--- FAIL: TestLogLocalDoesNotFormatWithoutFields/VerbLikeSequence
      "parse \"%!s(MISSING)\" failed" does not contain "parse \"%s\" failed"
```

Two positive tests pin the intended convention: fields **are** formatted when present, and a field with no verb to land on is appended rather than dropped — which is what makes the divergence between the presets lossless rather than lossy.

One correction the red check forced: I first wrote that a verb with no operand "stays literal". It does not — it becomes `%!s(MISSING)`. The doc says "marked in place" now.

`golangci-lint` 0 issues.

## Remaining in #372

The three "also worth a look" items: the `*bun.DB` leak when `Ping` fails, the discarded `tp.Shutdown` / `lp.Shutdown` errors in the sentry preset, and the test helpers that never drop their schema. All small; one PR.
