### PR TITLE
fix(golib): close leaked resources on the error and cleanup paths

### DIFF
--- a/otel/presets/sentry.go
+++ b/otel/presets/sentry.go
@@ -2,6 +2,7 @@ package otelpresets
 
 import (
 	"context"
+	stdlog "log"
 	"net/http"
 	"os"
 	"time"
@@ -114,12 +115,21 @@ func (config *Sentry) Flush() {
 		defer cancel()
 	}
 
+	// A failed drain drops whatever spans or logs were still buffered. On this
+	// backend that is the production telemetry, and dropping it silently is what the
+	// local and gcloud presets already log against.
 	if config.tp != nil {
-		_ = config.tp.Shutdown(ctx)
+		err := config.tp.Shutdown(ctx)
+		if err != nil {
+			stdlog.Printf("failed to shutdown tracer provider: %v\n", err)
+		}
 	}
 
 	if config.lp != nil {
-		_ = config.lp.Shutdown(ctx)
+		err := config.lp.Shutdown(ctx)
+		if err != nil {
+			stdlog.Printf("failed to shutdown logger provider: %v\n", err)
+		}
 	}
 
 	sentry.Flush(config.FlushTimeout)

--- a/postgres/isolated_schema_test.go
+++ b/postgres/isolated_schema_test.go
@@ -1,0 +1,89 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/postgres"
+)
+
+// schemaExists reports whether a schema is present, read through the primary connection
+// so it is independent of the per-schema pool under test.
+func schemaExists(ctx context.Context, t *testing.T, config postgres.Config, schema string) bool {
+	t.Helper()
+
+	db, err := config.DB(ctx)
+	require.NoError(t, err)
+
+	var count int
+
+	err = db.NewRaw(
+		"SELECT count(*) FROM information_schema.schemata WHERE schema_name = ?0", schema,
+	).Scan(ctx, &count)
+	require.NoError(t, err)
+
+	return count > 0
+}
+
+// The isolated helper stands up a randomly named schema per call. Without a drop, both
+// the schema and its cached pool live forever. This pins that the schema is gone once the
+// test finishes.
+func TestRunIsolatedTransactionalTestDropsItsSchema(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t)
+
+	var schema string
+
+	// Registered before the helper, so by cleanup LIFO it runs after the helper's own
+	// drop — this is the assertion that the drop happened.
+	t.Cleanup(func() {
+		require.NotEmpty(t, schema)
+		require.False(t, schemaExists(context.Background(), t, config, schema),
+			"the schema must be dropped after the isolated test")
+	})
+
+	postgres.RunIsolatedTransactionalTest(t, config, migrations, func(ctx context.Context, t *testing.T) {
+		t.Helper()
+
+		db, err := postgres.GetContext(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, db.NewRaw("SELECT current_schema()").Scan(ctx, &schema))
+		require.True(t, schemaExists(ctx, t, config, schema), "schema must exist during the test")
+	})
+}
+
+func TestDropSchemaEvictsTheCachedPool(t *testing.T) {
+	t.Parallel()
+
+	config := testConfig(t)
+
+	dropper, ok := config.(interface {
+		DropSchema(ctx context.Context, schema string) error
+	})
+	require.True(t, ok, "the Default preset must offer DropSchema")
+
+	ctx := context.Background()
+
+	_, schema, err := postgres.NewContextTest(ctx, config)
+	require.NoError(t, err)
+	require.True(t, schemaExists(ctx, t, config, schema))
+
+	require.NoError(t, dropper.DropSchema(ctx, schema))
+	require.False(t, schemaExists(ctx, t, config, schema))
+
+	// A second drop is a no-op: the pool is gone from the cache and DROP ... IF EXISTS
+	// tolerates the absent schema.
+	require.NoError(t, dropper.DropSchema(ctx, schema))
+
+	// Requesting the schema again opens a fresh pool, proving the old one was evicted
+	// rather than handed back closed.
+	reopened, err := config.DBSchema(ctx, schema, true)
+	require.NoError(t, err)
+	require.NoError(t, reopened.PingContext(ctx))
+
+	require.NoError(t, dropper.DropSchema(ctx, schema))
+}

--- a/postgres/presets/default.go
+++ b/postgres/presets/default.go
@@ -19,6 +19,11 @@ const (
 	// interpolated into the statement.
 	CreateSchema = "CREATE SCHEMA IF NOT EXISTS %s;"
 
+	// dropSchemaStmt is the counterpart for DropSchema. CASCADE takes the objects
+	// created inside the schema with it, so a migrated test schema drops in one
+	// statement.
+	dropSchemaStmt = "DROP SCHEMA IF EXISTS %s CASCADE;"
+
 	// MaxIdleConnsDefault is the number of idle connections a pool keeps when the
 	// caller expresses no preference.
 	//
@@ -78,10 +83,13 @@ func (config *Default) DB(ctx context.Context) (*bun.DB, error) {
 		db := bun.NewDB(sqldb, pgdialect.New(), bun.WithDiscardUnknownColumns())
 		db.SetMaxIdleConns(config.maxIdleConns())
 		db.SetMaxOpenConns(config.MaxOpenConns)
-		db.SetMaxOpenConns(config.MaxOpenConns)
 
 		err := postgres.Ping(ctx, db)
 		if err != nil {
+			// The pool is not cached on this path, so nothing else will close it. Its
+			// idle connections would otherwise outlive the failed call.
+			_ = db.Close()
+
 			return nil, fmt.Errorf("ping database: %w", err)
 		}
 
@@ -127,12 +135,48 @@ func (config *Default) DBSchema(ctx context.Context, schema string, create bool)
 
 	err = postgres.Ping(ctx, db)
 	if err != nil {
+		// Not yet cached in config.schemas, so this call owns the only reference.
+		_ = db.Close()
+
 		return nil, fmt.Errorf("ping database schema %s: %w", schema, err)
 	}
 
 	config.schemas[schema] = db
 
 	return db, nil
+}
+
+// DropSchema removes a schema created through DBSchema and releases the pool cached for
+// it. It is a test-support operation — production schemas are not dropped — and pairs
+// with the throwaway schema RunIsolatedTransactionalTest stands up.
+//
+// Without it, a randomly named schema and its pool are both kept forever: the schema
+// accumulates in the database, and the pool holds idle connections against a schema
+// nothing will query again.
+func (config *Default) DropSchema(ctx context.Context, schema string) error {
+	config.mu.Lock()
+
+	if pool, exists := config.schemas[schema]; exists {
+		// Close before dropping, so no session is left holding the schema in its
+		// search_path.
+		_ = pool.Close()
+
+		delete(config.schemas, schema)
+	}
+
+	config.mu.Unlock()
+
+	db, err := config.DB(ctx)
+	if err != nil {
+		return fmt.Errorf("get main db: %w", err)
+	}
+
+	_, err = db.NewRaw(fmt.Sprintf(dropSchemaStmt, schema)).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("drop schema %s: %w", schema, err)
+	}
+
+	return nil
 }
 
 // Options returns a copy of the driver options the config was built with.

--- a/postgres/test.go
+++ b/postgres/test.go
@@ -25,18 +25,26 @@ import (
 // context carrying the connection isolated for that test.
 type TransactionalTestFunc func(context.Context, *testing.T)
 
-// NewContextTest derives a context bound to a fresh, randomly named schema
-// created through config, isolating the test from others sharing the database.
-func NewContextTest(ctx context.Context, config Config) (context.Context, error) {
+// schemaDropper is the optional capability a Config offers to remove a schema created
+// through DBSchema. The bundled Default implements it; a Config that does not simply
+// leaves its throwaway schemas in place, as before.
+type schemaDropper interface {
+	DropSchema(ctx context.Context, schema string) error
+}
+
+// NewContextTest derives a context bound to a fresh, randomly named schema created
+// through config, isolating the test from others sharing the database. It returns the
+// schema name so the caller can drop it once done.
+func NewContextTest(ctx context.Context, config Config) (context.Context, string, error) {
 	schemaName := "ta_" + strings.ToLower(rand.Text())
 	schemaName = fmt.Sprintf("%.*s", NameLen, schemaName)
 
 	db, err := config.DBSchema(ctx, schemaName, true)
 	if err != nil {
-		return nil, fmt.Errorf("get db from config: %w", err)
+		return nil, "", fmt.Errorf("get db from config: %w", err)
 	}
 
-	return context.WithValue(ctx, ContextKey{}, db), nil
+	return context.WithValue(ctx, ContextKey{}, db), schemaName, nil
 }
 
 // RunIsolatedTransactionalTest runs callback in a throwaway schema, which admits
@@ -49,8 +57,19 @@ func NewContextTest(ctx context.Context, config Config) (context.Context, error)
 func RunIsolatedTransactionalTest(t *testing.T, config Config, migrations fs.FS, callback TransactionalTestFunc) {
 	t.Helper()
 
-	ctx, err := NewContextTest(t.Context(), config)
+	ctx, schema, err := NewContextTest(t.Context(), config)
 	require.NoError(t, err)
+
+	if dropper, ok := config.(schemaDropper); ok {
+		t.Cleanup(func() {
+			// t.Context is cancelled by the time cleanup runs, so the drop gets a fresh
+			// context. A failure here leaks the schema but must not fail the test.
+			dropErr := dropper.DropSchema(context.WithoutCancel(ctx), schema)
+			if dropErr != nil {
+				t.Logf("drop test schema %s: %v", schema, dropErr)
+			}
+		})
+	}
 
 	require.NoError(t, RunMigrationsContext(ctx, migrations))
 


### PR DESCRIPTION
The three "also worth a look" items from #372, one PR. Each leaks on a path that runs rarely enough to hide, and **closing #372**.

## 1 — `*bun.DB` leaked when `Ping` fails

`postgres/presets/default.go`, both `DB` and `DBSchema`:

```go
db := bun.NewDB(...)
err := postgres.Ping(ctx, db)
if err != nil {
    return nil, fmt.Errorf(...)   // db never closed, never cached, never reachable again
}
```

`postgres/test.go` already closes on this path; the preset did not. Both now do. Bounded today — all services call once at startup and panic on failure — but a leak on the error path is exactly the kind that surfaces the day something adds a retry.

Dropped a duplicate `SetMaxOpenConns(config.MaxOpenConns)` in `DB` while there.

## 2 — Sentry `Flush` discarded the Shutdown errors

`otel/presets/sentry.go` had `_ = config.tp.Shutdown(ctx)` where `local.go` and `gcloud.go` log it. A failed drain drops whatever spans and logs were still buffered — and Sentry is the **production** backend, so this is the one deployment where losing them matters, silently, while the dev backends complain. Now logs the same way, via the same `stdlog.Printf`.

## 3 — isolated test helper never dropped its schema

`RunIsolatedTransactionalTest` → `NewContextTest` creates a randomly named schema per call and never drops it, and `DBSchema` **caches one pool per schema name forever**. So both accumulate: schemas in the database, idle connections against schemas nothing will query again.

Zero callers today — the issue flagged it as *"worth fixing before the first one lands"*, and a narrative engine refreshing a materialized view is the obvious first one.

Fixed completely, not halfway:

- **`Default.DropSchema`** closes and evicts the cached pool, then drops the schema with `CASCADE`. Closing before dropping means no session is left holding the schema in its `search_path`.
- **`RunIsolatedTransactionalTest`** registers it as a `t.Cleanup` through an **optional interface** (`schemaDropper`), so this stays off the production `Config` interface — a `Config` that cannot drop simply leaves its schemas as before, exactly as today.
- **`NewContextTest` now returns the schema name.** Breaking signature change; one in-repo caller, none outside, and golib is v0.x so it rides a minor.

## Verified against a real Postgres

Not asserted — run against a container:

- the isolated helper's schema is **gone** once the test finishes (red check: the schema survives against the previous helper),
- `DropSchema` evicts the pool, so the next `DBSchema` for that name opens a **fresh** one rather than handing back a closed pool,
- a second drop is a clean no-op (`DROP ... IF EXISTS` + already-evicted cache).

One thing the tests encode that's easy to get wrong: `t.Cleanup` runs **LIFO**, so the drop-assertion is registered *before* `RunIsolatedTransactionalTest` — the helper's own drop cleanup, registered later, runs first, and the assertion sees the result.

Full suite green against the DB, `golangci-lint` 0 issues.

## #372 done

All three main items shipped (#395 LoadEnv, #397 capture writer, #398 logging) and now these three. Nothing left on the issue.
