### PR TITLE
chore(ci): drop the go-report-card job and README badge

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -86,13 +86,3 @@ jobs:
       - uses: a-novel-kit/workflows/go-actions/test-go@v1.23.1
         with:
           modfile: gotestsum.mod
-
-  report-grc:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && success()
-    needs: [test-go, lint-go]
-    permissions:
-      contents: read
-    steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.23.1
-        if: github.ref == 'refs/heads/master' && success()

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Shared Go library for the A-Novel backend services — the glue they'd otherwise
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/a-novel-kit/golib)
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel-kit/golib/main.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/a-novel-kit/golib)](https://goreportcard.com/report/github.com/a-novel-kit/golib)
 
 ## What this is
 


### PR DESCRIPTION
## Summary

- Removes the post-merge `report-grc` job and the Go Report Card README badge.
- [Go Report Card was sunset](https://goreportcard.com/report/github.com/a-novel/service-authentication) in July 2026 — the job POSTed to a now-dead endpoint and the badge renders broken. `golangci-lint` (the `lint-go` check) remains the real static-analysis gate.

## Breaking changes

None.

## Test plan

- [ ] CI green