### PR TITLE
feat(httpf): remove the deprecated SendJSON

### DIFF
--- a/docs/migrations/v0.28.0.md
+++ b/docs/migrations/v0.28.0.md
@@ -1,0 +1,30 @@
+# Migrating to v0.28.0
+
+`httpf.SendJSON` is removed. It was deprecated in v0.26.0 in favour of `httpf.SendJSONStatus`.
+
+## Do I need to act?
+
+**Only if you still call `httpf.SendJSON`.** Every Agora service migrated before this release, so the
+in-tree consumers need nothing.
+
+If a call remains, it will no longer compile. Replace it with `SendJSONStatus`, passing the status the
+old call implied:
+
+```go
+// before
+httpf.SendJSON(ctx, w, span, body)
+
+// after
+httpf.SendJSONStatus(ctx, w, span, http.StatusOK, body)
+```
+
+`SendJSON` always answered `200`, so `http.StatusOK` reproduces it exactly. A handler that set a
+different status before the call was already answering `text/plain` — see the v0.26.0 note — so pass
+that status here and the response now carries `application/json` as well.
+
+## Why it was removed rather than kept as a shorthand
+
+`SendJSON`'s signature takes no status, so it can only answer `200`. A caller wanting any other status
+had to send it before the call, which froze the header set before `SendJSON` could set the content
+type — the defect `SendJSONStatus` exists to make unrepresentable. Keeping the shorthand kept that
+trap reachable.

--- a/httpf/json.go
+++ b/httpf/json.go
@@ -36,13 +36,3 @@ func SendJSONStatus[Data any](
 
 	otel.ReportSuccessNoContent(span)
 }
-
-// SendJSON encodes data as JSON to w with a 200 status, and records the outcome on the
-// span.
-//
-// Deprecated: use [SendJSONStatus], passing http.StatusOK for the same response. This
-// signature cannot answer under any other status — a caller that sends one first loses
-// the JSON content type, which is what [SendJSONStatus] exists to make impossible.
-func SendJSON[Data any](ctx context.Context, w http.ResponseWriter, span trace.Span, data Data) {
-	SendJSONStatus(ctx, w, span, http.StatusOK, data)
-}

--- a/httpf/json_test.go
+++ b/httpf/json_test.go
@@ -99,20 +99,6 @@ func TestSendJSONStatus(t *testing.T) {
 	}
 }
 
-func TestSendJSONKeepsTheJSONContentType(t *testing.T) {
-	t.Parallel()
-
-	// The deprecated signature still answers 200 with a JSON content type, so the 14
-	// call sites that never set a status are unaffected by the change.
-	got := call(t, func(w http.ResponseWriter, r *http.Request) {
-		httpf.SendJSON(r.Context(), w, noop.Span{}, map[string]int{"n": 1})
-	})
-
-	require.Equal(t, http.StatusOK, got.status)
-	require.Equal(t, "application/json", got.contentType)
-	require.JSONEq(t, `{"n":1}`, got.body)
-}
-
 // Pins the behaviour the new signature exists to make unreachable: net/http freezes the
 // header set at WriteHeader, so a Content-Type written afterwards never leaves the
 // process and the client is told text/plain.


### PR DESCRIPTION
Closes #394 — the removal stage of the `SendJSON` → `SendJSONStatus` rollout (#371 → #393 → consumer migrations → this).

## The precondition is met

#394's own verification step: *"Empty across every consuming repo is the precondition for deletion. Worth re-running rather than trusting the checkboxes."* I re-ran it against each consumer's **default branch** (not a local checkout — the local trees were up to 17 commits stale, which nearly had me report the opposite):

```
git grep 'SendJSON(' origin/master -- '*.go' | grep -v SendJSONStatus
```

| Repo | Deprecated `SendJSON` refs |
|---|---|
| service-authentication | 0 |
| service-json-keys | 0 |
| service-template | 0 |
| service-narrative-engine | 0 |

All four migrated when they picked up v0.26.0. No consumer calls the symbol.

## The change

- Delete `SendJSON` from `httpf/json.go`.
- Delete `TestSendJSONKeepsTheJSONContentType`, its delegation test. The tests that pin `SendJSONStatus` and the net/http header-freeze behaviour it works around stay — those cover the surviving surface.

## Release

**Breaking** — an exported symbol is gone. golib is pre-1.0, so it rides a **minor** (`v0.28.0`) per the convention the earlier guides follow, with `docs/migrations/v0.28.0.md`. No in-tree consumer needs to act; the note is for any external caller.

`httpf` tests green, `golangci-lint` 0 issues, prettier clean, and `grep -rn 'SendJSON('` across golib returns nothing but `SendJSONStatus`.

## After this

The three-stage rollout is complete: the status-taking symbol added (#393, v0.26.0), consumers migrated, the shorthand removed (here). Cutting v0.28.0 is the last step, and the bump to it across services is Renovate's — none of them use the removed symbol, so it's a clean upgrade.
