### PR TITLE
ci(ci): cut cost-only job edges from the main graph

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -104,8 +104,6 @@ jobs:
           version: "1.28.0"
 
   test-go:
-    # No needs. lint-go used to sit here, on its own runner and its own checkout, where its
-    # verdict could not change this job's — it only delayed the tests by a lint run.
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,6 @@ jobs:
 
   lint-go:
     runs-on: ubuntu-latest
-    needs: [generated-go]
     permissions:
       contents: read
     steps:
@@ -105,7 +104,8 @@ jobs:
           version: "1.28.0"
 
   test-go:
-    needs: [lint-go]
+    # No needs. lint-go used to sit here, on its own runner and its own checkout, where its
+    # verdict could not change this job's — it only delayed the tests by a lint run.
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fleet-wide sweep over `main.yaml`. A `needs:` edge now exists only where the downstream job
consumes something the upstream one produces — an image digest, a coverage artifact ID, a file on
disk. Edges that only meant *don't spend a runner if the previous check failed* are gone: those jobs
run on separate runners against separate checkouts, so an upstream verdict never changed a
downstream one, and each such edge cost the whole graph one job's latency.

Both edges in this repo were cost-only: `lint-go` waited on `generated-go`, and `test-go` waited on
`lint-go`. Neither upstream job produces anything the downstream one reads.

## Effect

Critical path, simulated against the per-job durations of this repo's last green `master` run:

| | before | after |
| --- | --- | --- |
| whole run | 2.7 min | **1.2 min** |
| time to all required checks (i.e. mergeable) | 2.7 min | **1.2 min** (−57%) |

Every job now starts at t=0; the run is bounded by whichever of `lint-go` and `test-go` is slower.

A red check still blocks the merge — `merge-gate` holds that, not the graph shape. What changed is
that a failing lint no longer withholds the test result, so a run reports every failure it has in
one pass instead of one layer at a time.

## Required checks

No job was added, renamed or removed. The set of job IDs `main.yaml` declares is identical to
`master`'s, so the derived required-check list is unchanged and **no `a-novel repo update` is
needed**.

## Test plan

- [x] every file parses; no cycles; every `needs:` names a declared job
- [x] every `needs.X` expression names a job that is actually in that job's `needs` list
- [x] `prettier --check` clean
- [x] `zizmor` 1.28.0 clean, run offline with the fleet baseline config
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)