### PR TITLE
feat: add smtp.BoundedSender and otel.RecoverPanic

### DIFF
--- a/otel/utils.go
+++ b/otel/utils.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// errRecoveredPanic marks an error produced from a panic value absorbed by [RecoverPanic].
+// errRecoveredPanic wraps panic values absorbed by [RecoverPanic].
 var errRecoveredPanic = errors.New("recovered panic")
 
 // AppName is the instrumentation scope name stamped on every tracer and logger
@@ -58,12 +58,10 @@ func ReportSuccessNoContent(span trace.Span) {
 	span.SetStatus(codes.Ok, "")
 }
 
-// RecoverPanic stops a panic from escaping the calling goroutine: it records the panic on span
-// and logs it with a stack trace. Defer it directly — recover only works from a function the
-// panicking goroutine deferred itself.
+// RecoverPanic absorbs a panic on the calling goroutine, recording it on span and logging it
+// with a stack trace. Defer it directly; recover only works from a deferred function.
 //
-// Use it on detached goroutines. HTTP servers recover their handler goroutines; a panic escaping
-// any other goroutine ends the process.
+// Use it on detached goroutines, where an escaped panic ends the process.
 func RecoverPanic(ctx context.Context, span trace.Span) {
 	rec := recover()
 	if rec == nil {

--- a/otel/utils.go
+++ b/otel/utils.go
@@ -1,13 +1,20 @@
 package otel
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"log/slog"
+	"runtime/debug"
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// errRecoveredPanic marks an error produced from a panic value absorbed by [RecoverPanic].
+var errRecoveredPanic = errors.New("recovered panic")
 
 // AppName is the instrumentation scope name stamped on every tracer and logger
 // created through this package. Set it once at startup with SetAppName.
@@ -49,4 +56,20 @@ func ReportSuccess[Resp any](span trace.Span, resp Resp) Resp {
 // ReportSuccessNoContent marks the span successful when there is no value to return.
 func ReportSuccessNoContent(span trace.Span) {
 	span.SetStatus(codes.Ok, "")
+}
+
+// RecoverPanic stops a panic from escaping the calling goroutine: it records the panic on span
+// and logs it with a stack trace. Defer it directly — recover only works from a function the
+// panicking goroutine deferred itself.
+//
+// Use it on detached goroutines. HTTP servers recover their handler goroutines; a panic escaping
+// any other goroutine ends the process.
+func RecoverPanic(ctx context.Context, span trace.Span) {
+	rec := recover()
+	if rec == nil {
+		return
+	}
+
+	err := fmt.Errorf("%w: %v", errRecoveredPanic, rec)
+	Logger().ErrorContext(ctx, ReportError(span, err).Error()+"\n"+string(debug.Stack()))
 }

--- a/otel/utils_test.go
+++ b/otel/utils_test.go
@@ -14,7 +14,7 @@ func TestRecoverPanic(t *testing.T) {
 
 		done := make(chan struct{})
 
-		// Reaching done is the assertion: a panic RecoverPanic misses ends the test binary itself.
+		// A missed panic ends the test binary; reaching done is the assertion.
 		go func() {
 			defer close(done)
 

--- a/otel/utils_test.go
+++ b/otel/utils_test.go
@@ -1,0 +1,39 @@
+package otel_test
+
+import (
+	"testing"
+
+	"github.com/a-novel-kit/golib/otel"
+)
+
+func TestRecoverPanic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AbsorbsAPanic", func(t *testing.T) {
+		t.Parallel()
+
+		done := make(chan struct{})
+
+		// Reaching done is the assertion: a panic RecoverPanic misses ends the test binary itself.
+		go func() {
+			defer close(done)
+
+			_, span := otel.Tracer().Start(t.Context(), "test.RecoverPanic")
+			defer span.End()
+			defer otel.RecoverPanic(t.Context(), span)
+
+			panic("boom")
+		}()
+
+		<-done
+	})
+
+	t.Run("NoOpWithoutAPanic", func(t *testing.T) {
+		t.Parallel()
+
+		_, span := otel.Tracer().Start(t.Context(), "test.RecoverPanic")
+		defer span.End()
+
+		otel.RecoverPanic(t.Context(), span)
+	})
+}

--- a/smtp/sender.bounded.go
+++ b/smtp/sender.bounded.go
@@ -1,0 +1,36 @@
+package smtp
+
+import (
+	"text/template"
+)
+
+// BoundedSender is a [Sender] that caps concurrent deliveries; sends past the cap wait for a
+// free slot.
+//
+// ProdSender holds one connection per delivery, up to its full timeout, so concurrent callers
+// pile up connections during a burst or a server stall. The cap bounds the connections; callers
+// queue.
+type BoundedSender struct {
+	sender Sender
+	slots  chan struct{}
+}
+
+// NewBoundedSender wraps sender so at most limit deliveries run concurrently. A limit below one
+// is raised to one.
+func NewBoundedSender(sender Sender, limit int) *BoundedSender {
+	return &BoundedSender{sender: sender, slots: make(chan struct{}, max(limit, 1))}
+}
+
+// SendMail waits for a delivery slot, then delegates to the wrapped sender.
+func (bounded *BoundedSender) SendMail(to MailUsers, t *template.Template, tName string, data any) error {
+	bounded.slots <- struct{}{}
+	defer func() { <-bounded.slots }()
+
+	return bounded.sender.SendMail(to, t, tName, data)
+}
+
+// Ping delegates to the wrapped sender without taking a delivery slot, so readiness answers
+// while every slot is busy.
+func (bounded *BoundedSender) Ping() error {
+	return bounded.sender.Ping()
+}

--- a/smtp/sender.bounded.go
+++ b/smtp/sender.bounded.go
@@ -4,24 +4,19 @@ import (
 	"text/template"
 )
 
-// BoundedSender is a [Sender] that caps concurrent deliveries; sends past the cap wait for a
-// free slot.
-//
-// ProdSender holds one connection per delivery, up to its full timeout, so concurrent callers
-// pile up connections during a burst or a server stall. The cap bounds the connections; callers
-// queue.
+// BoundedSender is a [Sender] that caps concurrent deliveries; excess sends wait for a slot.
+// ProdSender holds one connection per delivery, so an unbounded burst piles up connections.
 type BoundedSender struct {
 	sender Sender
 	slots  chan struct{}
 }
 
-// NewBoundedSender wraps sender so at most limit deliveries run concurrently. A limit below one
-// is raised to one.
+// NewBoundedSender caps sender at limit concurrent deliveries; a limit below one becomes one.
 func NewBoundedSender(sender Sender, limit int) *BoundedSender {
 	return &BoundedSender{sender: sender, slots: make(chan struct{}, max(limit, 1))}
 }
 
-// SendMail waits for a delivery slot, then delegates to the wrapped sender.
+// SendMail waits for a slot, then delegates.
 func (bounded *BoundedSender) SendMail(to MailUsers, t *template.Template, tName string, data any) error {
 	bounded.slots <- struct{}{}
 	defer func() { <-bounded.slots }()
@@ -29,8 +24,7 @@ func (bounded *BoundedSender) SendMail(to MailUsers, t *template.Template, tName
 	return bounded.sender.SendMail(to, t, tName, data)
 }
 
-// Ping delegates to the wrapped sender without taking a delivery slot, so readiness answers
-// while every slot is busy.
+// Ping delegates without taking a slot, so probes never queue behind sends.
 func (bounded *BoundedSender) Ping() error {
 	return bounded.sender.Ping()
 }

--- a/smtp/sender.bounded_test.go
+++ b/smtp/sender.bounded_test.go
@@ -1,0 +1,133 @@
+package smtp_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/smtp"
+)
+
+// countingSender tracks how many deliveries run at once, holding each one open until released.
+type countingSender struct {
+	mu      sync.Mutex
+	current int
+	peak    int
+	release chan struct{}
+	err     error
+	pingErr error
+}
+
+func (sender *countingSender) SendMail(_ smtp.MailUsers, _ *template.Template, _ string, _ any) error {
+	sender.mu.Lock()
+	sender.current++
+	sender.peak = max(sender.peak, sender.current)
+	sender.mu.Unlock()
+
+	if sender.release != nil {
+		<-sender.release
+	}
+
+	sender.mu.Lock()
+	sender.current--
+	sender.mu.Unlock()
+
+	return sender.err
+}
+
+func (sender *countingSender) Ping() error { return sender.pingErr }
+
+func (sender *countingSender) running() int {
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+
+	return sender.current
+}
+
+func TestBoundedSender(t *testing.T) {
+	t.Parallel()
+
+	errFoo := errors.New("foo")
+
+	t.Run("CapsConcurrentDeliveries", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &countingSender{release: make(chan struct{})}
+		sender := smtp.NewBoundedSender(inner, 2)
+
+		errs := make(chan error, 6)
+
+		var wg sync.WaitGroup
+
+		for range 6 {
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				errs <- sender.SendMail(nil, nil, "", nil)
+			}()
+		}
+
+		// Two deliveries hold the slots; the four others are parked waiting for one.
+		require.Eventually(t, func() bool { return inner.running() == 2 }, time.Second, time.Millisecond)
+
+		close(inner.release)
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, 2, inner.peak)
+	})
+
+	t.Run("PingSkipsDeliverySlots", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &countingSender{release: make(chan struct{})}
+		sender := smtp.NewBoundedSender(inner, 1)
+
+		errs := make(chan error, 1)
+
+		go func() { errs <- sender.SendMail(nil, nil, "", nil) }()
+
+		require.Eventually(t, func() bool { return inner.running() == 1 }, time.Second, time.Millisecond)
+
+		// The only slot is busy; Ping returning at all is the assertion.
+		require.NoError(t, sender.Ping())
+
+		close(inner.release)
+		require.NoError(t, <-errs)
+	})
+
+	t.Run("PropagatesDeliveryErrors", func(t *testing.T) {
+		t.Parallel()
+
+		sender := smtp.NewBoundedSender(&countingSender{err: errFoo}, 2)
+
+		require.ErrorIs(t, sender.SendMail(nil, nil, "", nil), errFoo)
+	})
+
+	t.Run("PropagatesPingErrors", func(t *testing.T) {
+		t.Parallel()
+
+		sender := smtp.NewBoundedSender(&countingSender{pingErr: errFoo}, 2)
+
+		require.ErrorIs(t, sender.Ping(), errFoo)
+	})
+
+	t.Run("RaisesALimitBelowOne", func(t *testing.T) {
+		t.Parallel()
+
+		sender := smtp.NewBoundedSender(&countingSender{}, 0)
+
+		// A zero-capacity slot channel never grants a slot; completing at all is the assertion.
+		require.NoError(t, sender.SendMail(nil, nil, "", nil))
+	})
+}


### PR DESCRIPTION
## Summary

- `smtp.BoundedSender`: a `Sender` decorator capping concurrent deliveries. `ProdSender` holds one connection per delivery for up to its full timeout, so every consumer firing sends concurrently inherits the same unbounded-connections failure shape; the mitigation belongs beside the cause. `Ping` bypasses the slots so readiness keeps answering while all slots are busy.
- `otel.RecoverPanic`: deferred panic recovery for detached goroutines — records the panic on the caller's span, logs it with a stack trace. golib has no panic handling anywhere today; HTTP servers only cover handler goroutines.

Both are extractions from `a-novel/service-authentication#1180`, which re-pins and swaps to these once this releases (minor, v0.29.0). service-jobs' worker goroutines are the next `RecoverPanic` consumer.

## Breaking changes

None.

## Test plan

- [x] `go test ./smtp/... ./otel/...` passes
- [x] Full suite passes locally (postgres package against a throwaway database)
- [x] `pnpm lint:go` clean
- [ ] CI green