### PR TITLE
feat(postgres): prove every down migration reverses its up

### DIFF
--- a/postgres/census.go
+++ b/postgres/census.go
@@ -1,0 +1,139 @@
+package postgres
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/uptrace/bun"
+)
+
+// censusQuery renders a schema as sorted (class, identity, definition) rows. Its own header
+// documents the invariants it upholds.
+//
+//go:embed census.sql
+var censusQuery string
+
+// ErrUnsupportedSchemaObject is returned by [SchemaSnapshot] when the schema holds an object class
+// the census cannot render, such as an aggregate or a custom operator.
+//
+// A snapshot that quietly omitted such an object would compare equal to one taken before it
+// existed, so the whole point of the snapshot — proving nothing was left behind — would be lost on
+// exactly the object nobody thought to cover. Teaching census.sql the class is the fix.
+var ErrUnsupportedSchemaObject = errors.New("schema holds an object class the census cannot render")
+
+// censusBookkeepingPrefix marks the tables bun's migrator keeps for itself. They record which
+// migrations ran, so they exist at every step of a rollback and describe the harness rather than
+// the schema under test.
+//
+// The prefix, rather than the two exact names, also covers the indexes and constraints those tables
+// own. A caller's own table starting with it would be invisible to the census.
+const censusBookkeepingPrefix = "bun_migration"
+
+// censusClassUnsupported is the class census.sql gives an object it cannot render, so a gap in
+// coverage arrives as a row to fail on rather than as silence.
+const censusClassUnsupported = "unsupported"
+
+// censusRow is one object in a schema census.
+type censusRow struct {
+	Class      string `bun:"class"`
+	Identity   string `bun:"identity"`
+	Definition string `bun:"definition"`
+}
+
+// SchemaSnapshot renders every object in schema as canonical, sorted text, one line per object.
+// Two schemas are identical exactly when their snapshots are, which is what makes a snapshot usable
+// as a fixture: [RunMigrationRoundtripTest] compares one against the next to prove a rollback
+// landed where it should.
+//
+// The rendering is stable across databases and across the order statements were run in, so a
+// snapshot can be committed and diffed. PostgreSQL renders the definitions itself, so a snapshot
+// describes the schema that exists rather than the DDL that produced it.
+//
+// Alongside the objects in schema it covers extensions and schemas, which are database-scoped but
+// which a migration can create and a rollback must therefore remove. It reads no row data.
+//
+// It returns [ErrUnsupportedSchemaObject] when the schema holds a class the census cannot render.
+func SchemaSnapshot(ctx context.Context, db bun.IDB, schema string) (string, error) {
+	var rows []censusRow
+
+	err := db.NewRaw(censusQuery, schema).Scan(ctx, &rows)
+	if err != nil {
+		return "", fmt.Errorf("census schema %q: %w", schema, err)
+	}
+
+	var (
+		unsupported []string
+		out         strings.Builder
+	)
+
+	for _, row := range rows {
+		if row.Class == censusClassUnsupported {
+			unsupported = append(unsupported, row.Identity+" "+row.Definition)
+
+			continue
+		}
+
+		if strings.HasPrefix(row.Identity, censusBookkeepingPrefix) {
+			continue
+		}
+
+		out.WriteString(row.Class)
+		out.WriteByte('\t')
+		out.WriteString(row.Identity)
+		out.WriteByte('\t')
+		out.WriteString(row.Definition)
+		out.WriteByte('\n')
+	}
+
+	if len(unsupported) > 0 {
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedSchemaObject, strings.Join(unsupported, "; "))
+	}
+
+	return out.String(), nil
+}
+
+// SnapshotDelta reports how got differs from want, as one line per object, or nil when the two
+// snapshots are identical.
+//
+// Lines are compared as a set, so the report names the objects that actually differ instead of the
+// point where two orderings diverged. The result is sorted, so a failure message reads the same on
+// every run.
+func SnapshotDelta(want, got string) []string {
+	wantLines, gotLines := snapshotLines(want), snapshotLines(got)
+
+	var delta []string
+
+	for line := range wantLines {
+		if !gotLines[line] {
+			delta = append(delta, "missing: "+line)
+		}
+	}
+
+	for line := range gotLines {
+		if !wantLines[line] {
+			delta = append(delta, "unexpected: "+line)
+		}
+	}
+
+	slices.Sort(delta)
+
+	return delta
+}
+
+// snapshotLines indexes a snapshot by line. A snapshot holds one object per line and the census
+// sorts them, so a set comparison loses nothing and gains a per-object report.
+func snapshotLines(snapshot string) map[string]bool {
+	lines := map[string]bool{}
+
+	for line := range strings.SplitSeq(strings.TrimRight(snapshot, "\n"), "\n") {
+		if line != "" {
+			lines[line] = true
+		}
+	}
+
+	return lines
+}

--- a/postgres/census.go
+++ b/postgres/census.go
@@ -11,41 +11,28 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// censusQuery renders a schema as sorted (class, identity, definition) rows. Its own header
-// documents the invariants it upholds.
-//
 //go:embed census.sql
 var censusQuery string
 
-// censusCoverageQuery counts the objects censusQuery must render from each covered catalog. Keeping
-// the count independent makes an accidentally removed renderer fail every caller's snapshot.
+// Kept separate so removing a census renderer produces a coverage mismatch.
 //
 //go:embed censusCoverage.sql
 var censusCoverageQuery string
 
-// ErrUnsupportedSchemaObject is returned by [SchemaSnapshot] when the schema holds an object class
-// the census cannot render, such as an aggregate or a custom operator.
-//
-// A snapshot that quietly omitted such an object would compare equal to one taken before it
-// existed, so the whole point of the snapshot — proving nothing was left behind — would be lost on
-// exactly the object nobody thought to cover. Teaching census.sql the class is the fix.
+// ErrUnsupportedSchemaObject reports a schema object the census cannot safely compare. Such objects
+// fail instead of being silently omitted.
 var ErrUnsupportedSchemaObject = errors.New("schema holds an object class the census cannot render")
 
 const (
-	// censusMigrationsTable records which Bun migrations have run.
-	censusMigrationsTable = "bun_migrations"
-	// censusMigrationLocksTable serializes Bun migration runs.
+	censusMigrationsTable     = "bun_migrations"
 	censusMigrationLocksTable = "bun_migration_locks"
 )
 
-// censusClassUnsupported is the class census.sql gives an object it cannot render, so a gap in
-// coverage arrives as a row to fail on rather than as silence.
 const (
 	censusClassRelation    = "relation"
 	censusClassUnsupported = "unsupported"
 )
 
-// censusRow is one object in a schema census.
 type censusRow struct {
 	Class      string `bun:"class"`
 	Catalog    string `bun:"catalog"`
@@ -53,25 +40,16 @@ type censusRow struct {
 	Definition string `bun:"definition"`
 }
 
-// censusCoverageRow is the number of objects censusQuery must render from one catalog.
 type censusCoverageRow struct {
 	Catalog  string `bun:"catalog"`
 	Expected int    `bun:"expected"`
 }
 
-// SchemaSnapshot renders the supported objects in schema as canonical, sorted text, one line per
-// object. Two schemas are identical within that supported surface exactly when their snapshots are,
-// which is what makes a snapshot usable as a fixture: [RunMigrationRoundtripTest] compares one
-// against the next to prove a rollback landed where it should.
+// SchemaSnapshot renders supported schema objects as canonical, sorted, one-line records.
+// PostgreSQL renders definitions, so statement order and DDL spelling do not affect the result.
 //
-// The rendering is stable across databases and across the order statements were run in, so a
-// snapshot can be committed and diffed. PostgreSQL renders the definitions itself, so a snapshot
-// describes the schema that exists rather than the DDL that produced it.
-//
-// Alongside the objects in schema it covers extensions and schemas, which are database-scoped but
-// which a migration can create and a rollback must therefore remove. It reads no row data.
-//
-// It returns [ErrUnsupportedSchemaObject] when the schema holds a class the census cannot render.
+// It includes database-scoped extensions and schemas, reads no row data, and returns
+// [ErrUnsupportedSchemaObject] rather than omitting an unsupported class.
 func SchemaSnapshot(ctx context.Context, db bun.IDB, schema string) (string, error) {
 	var rows []censusRow
 
@@ -126,7 +104,6 @@ func SchemaSnapshot(ctx context.Context, db bun.IDB, schema string) (string, err
 	return out.String(), nil
 }
 
-// isCensusBookkeepingObject identifies only the objects Bun's default migrator creates.
 func isCensusBookkeepingObject(row censusRow) bool {
 	switch row.Class {
 	case "column", "constraint":
@@ -155,7 +132,6 @@ func isCensusBookkeepingObject(row censusRow) bool {
 	}
 }
 
-// validateCensusCoverage proves the renderer accounted for every expected catalog row.
 func validateCensusCoverage(rows []censusRow, coverage []censusCoverageRow) error {
 	actual := make(map[string]int, len(coverage))
 
@@ -175,12 +151,8 @@ func validateCensusCoverage(rows []censusRow, coverage []censusCoverageRow) erro
 	return nil
 }
 
-// SnapshotDelta reports how got differs from want, as one line per object, or nil when the two
-// snapshots are identical.
-//
-// Lines are compared as a set, so the report names the objects that actually differ instead of the
-// point where two orderings diverged. The result is sorted, so a failure message reads the same on
-// every run.
+// SnapshotDelta returns sorted per-object differences between want and got.
+// Records are compared as a set.
 func SnapshotDelta(want, got string) []string {
 	wantLines, gotLines := snapshotLines(want), snapshotLines(got)
 
@@ -203,8 +175,6 @@ func SnapshotDelta(want, got string) []string {
 	return delta
 }
 
-// snapshotLines indexes a snapshot by line. A snapshot holds one object per line and the census
-// sorts them, so a set comparison loses nothing and gains a per-object report.
 func snapshotLines(snapshot string) map[string]bool {
 	lines := map[string]bool{}
 

--- a/postgres/census.go
+++ b/postgres/census.go
@@ -17,6 +17,12 @@ import (
 //go:embed census.sql
 var censusQuery string
 
+// censusCoverageQuery counts the objects censusQuery must render from each covered catalog. Keeping
+// the count independent makes an accidentally removed renderer fail every caller's snapshot.
+//
+//go:embed censusCoverage.sql
+var censusCoverageQuery string
+
 // ErrUnsupportedSchemaObject is returned by [SchemaSnapshot] when the schema holds an object class
 // the census cannot render, such as an aggregate or a custom operator.
 //
@@ -25,29 +31,38 @@ var censusQuery string
 // exactly the object nobody thought to cover. Teaching census.sql the class is the fix.
 var ErrUnsupportedSchemaObject = errors.New("schema holds an object class the census cannot render")
 
-// censusBookkeepingPrefix marks the tables bun's migrator keeps for itself. They record which
-// migrations ran, so they exist at every step of a rollback and describe the harness rather than
-// the schema under test.
-//
-// The prefix, rather than the two exact names, also covers the indexes and constraints those tables
-// own. A caller's own table starting with it would be invisible to the census.
-const censusBookkeepingPrefix = "bun_migration"
+const (
+	// censusMigrationsTable records which Bun migrations have run.
+	censusMigrationsTable = "bun_migrations"
+	// censusMigrationLocksTable serializes Bun migration runs.
+	censusMigrationLocksTable = "bun_migration_locks"
+)
 
 // censusClassUnsupported is the class census.sql gives an object it cannot render, so a gap in
 // coverage arrives as a row to fail on rather than as silence.
-const censusClassUnsupported = "unsupported"
+const (
+	censusClassRelation    = "relation"
+	censusClassUnsupported = "unsupported"
+)
 
 // censusRow is one object in a schema census.
 type censusRow struct {
 	Class      string `bun:"class"`
+	Catalog    string `bun:"catalog"`
 	Identity   string `bun:"identity"`
 	Definition string `bun:"definition"`
 }
 
-// SchemaSnapshot renders every object in schema as canonical, sorted text, one line per object.
-// Two schemas are identical exactly when their snapshots are, which is what makes a snapshot usable
-// as a fixture: [RunMigrationRoundtripTest] compares one against the next to prove a rollback
-// landed where it should.
+// censusCoverageRow is the number of objects censusQuery must render from one catalog.
+type censusCoverageRow struct {
+	Catalog  string `bun:"catalog"`
+	Expected int    `bun:"expected"`
+}
+
+// SchemaSnapshot renders the supported objects in schema as canonical, sorted text, one line per
+// object. Two schemas are identical within that supported surface exactly when their snapshots are,
+// which is what makes a snapshot usable as a fixture: [RunMigrationRoundtripTest] compares one
+// against the next to prove a rollback landed where it should.
 //
 // The rendering is stable across databases and across the order statements were run in, so a
 // snapshot can be committed and diffed. PostgreSQL renders the definitions itself, so a snapshot
@@ -65,10 +80,25 @@ func SchemaSnapshot(ctx context.Context, db bun.IDB, schema string) (string, err
 		return "", fmt.Errorf("census schema %q: %w", schema, err)
 	}
 
+	var coverage []censusCoverageRow
+
+	err = db.NewRaw(censusCoverageQuery, schema).Scan(ctx, &coverage)
+	if err != nil {
+		return "", fmt.Errorf("check census coverage for schema %q: %w", schema, err)
+	}
+
+	err = validateCensusCoverage(rows, coverage)
+	if err != nil {
+		return "", fmt.Errorf("check census coverage for schema %q: %w", schema, err)
+	}
+
 	var (
 		unsupported []string
 		out         strings.Builder
 	)
+
+	fieldEscaper := strings.NewReplacer(
+		`\`, `\\`, "\t", `\t`, "\r", `\r`, "\n", `\n`)
 
 	for _, row := range rows {
 		if row.Class == censusClassUnsupported {
@@ -77,15 +107,15 @@ func SchemaSnapshot(ctx context.Context, db bun.IDB, schema string) (string, err
 			continue
 		}
 
-		if strings.HasPrefix(row.Identity, censusBookkeepingPrefix) {
+		if isCensusBookkeepingObject(row) {
 			continue
 		}
 
-		out.WriteString(row.Class)
+		out.WriteString(fieldEscaper.Replace(row.Class))
 		out.WriteByte('\t')
-		out.WriteString(row.Identity)
+		out.WriteString(fieldEscaper.Replace(row.Identity))
 		out.WriteByte('\t')
-		out.WriteString(row.Definition)
+		out.WriteString(fieldEscaper.Replace(row.Definition))
 		out.WriteByte('\n')
 	}
 
@@ -94,6 +124,55 @@ func SchemaSnapshot(ctx context.Context, db bun.IDB, schema string) (string, err
 	}
 
 	return out.String(), nil
+}
+
+// isCensusBookkeepingObject identifies only the objects Bun's default migrator creates.
+func isCensusBookkeepingObject(row censusRow) bool {
+	switch row.Class {
+	case "column", "constraint":
+		return strings.HasPrefix(row.Identity, censusMigrationsTable+".") ||
+			strings.HasPrefix(row.Identity, censusMigrationLocksTable+".")
+	case censusClassRelation:
+		return row.Identity == censusMigrationsTable ||
+			row.Identity == censusMigrationLocksTable ||
+			row.Identity == censusMigrationsTable+"_id_seq" ||
+			row.Identity == censusMigrationLocksTable+"_id_seq"
+	case "sequence":
+		return row.Identity == censusMigrationsTable+"_id_seq" ||
+			row.Identity == censusMigrationLocksTable+"_id_seq"
+	case "index":
+		return row.Identity == censusMigrationsTable+"_pkey" ||
+			row.Identity == censusMigrationsTable+"_name_unique" ||
+			row.Identity == censusMigrationLocksTable+"_pkey" ||
+			row.Identity == censusMigrationLocksTable+"_table_name_key"
+	case "comment":
+		return row.Identity == censusMigrationsTable ||
+			row.Identity == censusMigrationLocksTable ||
+			strings.HasPrefix(row.Identity, censusMigrationsTable+".") ||
+			strings.HasPrefix(row.Identity, censusMigrationLocksTable+".")
+	default:
+		return false
+	}
+}
+
+// validateCensusCoverage proves the renderer accounted for every expected catalog row.
+func validateCensusCoverage(rows []censusRow, coverage []censusCoverageRow) error {
+	actual := make(map[string]int, len(coverage))
+
+	for _, row := range rows {
+		if row.Catalog != "" {
+			actual[row.Catalog]++
+		}
+	}
+
+	for _, expected := range coverage {
+		if actual[expected.Catalog] != expected.Expected {
+			return fmt.Errorf("schema census coverage for %s: rendered %d objects, catalog has %d",
+				expected.Catalog, actual[expected.Catalog], expected.Expected)
+		}
+	}
+
+	return nil
 }
 
 // SnapshotDelta reports how got differs from want, as one line per object, or nil when the two

--- a/postgres/census.sql
+++ b/postgres/census.sql
@@ -1,0 +1,402 @@
+-- A canonical, order-insensitive census of a schema, one row per object as
+-- (class, identity, definition).
+--
+-- Definitions are rendered by PostgreSQL itself through the pg_get_*def family — the same
+-- functions pg_dump uses — so however a migration spelled a thing, the catalog reports one
+-- canonical form. Rows are keyed by object identity rather than ordinal position, which is what
+-- lets a column re-added at the end of a table by a rollback read as identical.
+--
+-- Nothing derives from an OID. OIDs are assigned in creation order, so any leak would make an
+-- identical schema built by a different sequence of statements render different text.
+--
+-- Classes this census cannot render emit an 'unsupported' row instead of being skipped, turning a
+-- gap in coverage into a loud failure rather than a silent pass.
+--
+-- ?0 is the schema to census.
+WITH
+  -- Objects a CREATE EXTENSION brought in belong to the extension, which is censused in its own
+  -- right, so dropping its members here loses no coverage.
+  extension_owned AS (
+    SELECT
+      objid,
+      classid
+    FROM
+      pg_depend
+    WHERE
+      deptype = 'e'
+  ),
+  target AS (
+    SELECT
+      oid AS nsp
+    FROM
+      pg_namespace
+    WHERE
+      nspname = ?0
+  )
+SELECT
+  'column' AS class,
+  c.relname || '.' || a.attname AS identity,
+  format_type(a.atttypid, a.atttypmod) || CASE WHEN a.attnotnull THEN ' NOT NULL' ELSE '' END || coalesce(' DEFAULT ' || pg_get_expr(d.adbin, d.adrelid), '') || CASE WHEN a.attidentity <> '' THEN ' IDENTITY ' || a.attidentity::text ELSE '' END || CASE WHEN a.attgenerated <> '' THEN ' GENERATED ' || a.attgenerated::text ELSE '' END || coalesce(' COLLATE ' || nullif(co.collname, 'default'), '') AS definition
+FROM
+  pg_attribute a
+  JOIN pg_class c ON c.oid = a.attrelid
+  JOIN target ON c.relnamespace = target.nsp
+  LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid
+  AND d.adnum = a.attnum
+  LEFT JOIN pg_collation co ON co.oid = a.attcollation
+WHERE
+  a.attnum > 0
+  AND NOT a.attisdropped
+  -- 'c' covers the fields of a standalone composite type, which has no other home.
+  AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'c')
+UNION ALL
+SELECT
+  'relation',
+  c.relname,
+  c.relkind::text || coalesce(' OPTIONS ' || array_to_string(c.reloptions, ','), '') || CASE WHEN c.relrowsecurity THEN ' RLS' ELSE '' END || CASE WHEN c.relforcerowsecurity THEN ' FORCE_RLS' ELSE '' END || coalesce(' ACL ' || array_to_string(c.relacl::text[], ','), '') || coalesce(' PARTITION BY ' || pg_get_partkeydef(c.oid), '') || coalesce(' AS ' || pg_get_viewdef(c.oid, TRUE), '')
+FROM
+  pg_class c
+  JOIN target ON c.relnamespace = target.nsp
+WHERE
+  c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S', 'c')
+  AND NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = c.oid
+      AND e.classid = 'pg_class'::regclass
+  )
+UNION ALL
+SELECT
+  'sequence',
+  c.relname,
+  s.seqtypid::regtype || ' start ' || s.seqstart || ' inc ' || s.seqincrement || ' min ' || s.seqmin || ' max ' || s.seqmax || ' cache ' || s.seqcache || CASE WHEN s.seqcycle THEN ' cycle' ELSE '' END
+FROM
+  pg_sequence s
+  JOIN pg_class c ON c.oid = s.seqrelid
+  JOIN target ON c.relnamespace = target.nsp
+UNION ALL
+SELECT
+  'index',
+  c.relname,
+  pg_get_indexdef(i.indexrelid)
+FROM
+  pg_index i
+  JOIN pg_class c ON c.oid = i.indexrelid
+  JOIN target ON c.relnamespace = target.nsp
+UNION ALL
+SELECT
+  'constraint',
+  coalesce(rel.relname || '.', '') || con.conname,
+  pg_get_constraintdef(con.oid)
+FROM
+  pg_constraint con
+  JOIN target ON con.connamespace = target.nsp
+  LEFT JOIN pg_class rel ON rel.oid = con.conrelid
+UNION ALL
+SELECT
+  'type',
+  t.typname,
+  t.typtype::text || CASE WHEN t.typtype = 'e' THEN ' ' || coalesce(
+    (
+      SELECT
+        string_agg(e.enumlabel, ',' ORDER BY e.enumsortorder)
+      FROM
+        pg_enum e
+      WHERE
+        e.enumtypid = t.oid
+    ),
+    ''
+  ) WHEN t.typtype = 'd' THEN ' ' || format_type(t.typbasetype, t.typtypmod) || CASE WHEN t.typnotnull THEN ' NOT NULL' ELSE '' END || coalesce(' DEFAULT ' || t.typdefault, '') ELSE '' END
+FROM
+  pg_type t
+  JOIN target ON t.typnamespace = target.nsp
+WHERE
+  t.typtype IN ('e', 'd', 'c')
+  -- A table's row type is implied by the table. A standalone composite type also owns a pg_class
+  -- row, of relkind 'c', which is why only the other kinds are excluded here.
+  AND NOT EXISTS (
+    SELECT
+    FROM
+      pg_class c
+    WHERE
+      c.reltype = t.oid
+      AND c.relkind <> 'c'
+  )
+  AND NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = t.oid
+      AND e.classid = 'pg_type'::regclass
+  )
+UNION ALL
+SELECT
+  'routine',
+  p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')',
+  -- The body is hashed rather than embedded: a routine definition can run to hundreds of lines,
+  -- and the census is read as a diff where one changed line beats one changed page.
+  p.prokind::text || ' ' || md5(coalesce(p.prosrc, '')) || ' ' || pg_get_function_result(p.oid) || ' ' || p.provolatile::text || ' ' || p.proisstrict::text || ' ' || p.prosecdef::text || ' ' || l.lanname
+FROM
+  pg_proc p
+  JOIN target ON p.pronamespace = target.nsp
+  JOIN pg_language l ON l.oid = p.prolang
+WHERE
+  p.prokind <> 'a'
+  AND NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = p.oid
+      AND e.classid = 'pg_proc'::regclass
+  )
+UNION ALL
+SELECT
+  'trigger',
+  c.relname || '.' || tg.tgname,
+  pg_get_triggerdef(tg.oid)
+FROM
+  pg_trigger tg
+  JOIN pg_class c ON c.oid = tg.tgrelid
+  JOIN target ON c.relnamespace = target.nsp
+WHERE
+  NOT tg.tgisinternal
+UNION ALL
+SELECT
+  'policy',
+  c.relname || '.' || pol.polname,
+  pol.polcmd::text || ' ' || coalesce(pg_get_expr(pol.polqual, pol.polrelid), '-') || ' ' || coalesce(pg_get_expr(pol.polwithcheck, pol.polrelid), '-')
+FROM
+  pg_policy pol
+  JOIN pg_class c ON c.oid = pol.polrelid
+  JOIN target ON c.relnamespace = target.nsp
+UNION ALL
+SELECT
+  'rule',
+  c.relname || '.' || r.rulename,
+  pg_get_ruledef(r.oid)
+FROM
+  pg_rewrite r
+  JOIN pg_class c ON c.oid = r.ev_class
+  JOIN target ON c.relnamespace = target.nsp
+WHERE
+  -- Every view owns a _RETURN rule, already covered by the view's own definition.
+  r.rulename <> '_RETURN'
+UNION ALL
+SELECT
+  'statistics',
+  st.stxname,
+  pg_get_statisticsobjdef(st.oid)
+FROM
+  pg_statistic_ext st
+  JOIN target ON st.stxnamespace = target.nsp
+UNION ALL
+SELECT
+  'collation',
+  col.collname,
+  col.collprovider::text || ' ' || coalesce(col.collcollate, '-') || ' ' || coalesce(col.collctype, '-')
+FROM
+  pg_collation col
+  JOIN target ON col.collnamespace = target.nsp
+UNION ALL
+SELECT
+  'extension',
+  e.extname,
+  e.extversion
+FROM
+  pg_extension e
+UNION ALL
+SELECT
+  'schema',
+  n.nspname,
+  coalesce(array_to_string(n.nspacl::text[], ','), '')
+FROM
+  pg_namespace n
+WHERE
+  n.nspname NOT LIKE 'pg\_%'
+  AND n.nspname <> 'information_schema'
+  -- Comments are censused by the name of what they hang off, never by OID.
+UNION ALL
+SELECT
+  'comment',
+  c.relname || coalesce('.' || a.attname, ''),
+  d.description
+FROM
+  pg_description d
+  JOIN pg_class c ON c.oid = d.objoid
+  JOIN target ON c.relnamespace = target.nsp
+  LEFT JOIN pg_attribute a ON a.attrelid = d.objoid
+  AND a.attnum = d.objsubid
+UNION ALL
+SELECT
+  'comment',
+  'type ' || t.typname,
+  d.description
+FROM
+  pg_description d
+  JOIN pg_type t ON t.oid = d.objoid
+  JOIN target ON t.typnamespace = target.nsp
+UNION ALL
+SELECT
+  'comment',
+  'routine ' || p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')',
+  d.description
+FROM
+  pg_description d
+  JOIN pg_proc p ON p.oid = d.objoid
+  JOIN target ON p.pronamespace = target.nsp
+UNION ALL
+SELECT
+  'comment',
+  'constraint ' || coalesce(rel.relname || '.', '') || con.conname,
+  d.description
+FROM
+  pg_description d
+  JOIN pg_constraint con ON con.oid = d.objoid
+  JOIN target ON con.connamespace = target.nsp
+  LEFT JOIN pg_class rel ON rel.oid = con.conrelid
+UNION ALL
+SELECT
+  'comment',
+  'schema ' || n.nspname,
+  d.description
+FROM
+  pg_description d
+  JOIN pg_namespace n ON n.oid = d.objoid
+WHERE
+  n.nspname NOT LIKE 'pg\_%'
+  AND n.nspname <> 'information_schema'
+  -- Everything below reports what this census cannot render. A row here fails the caller rather
+  -- than letting an object class drop silently out of coverage.
+UNION ALL
+SELECT
+  'unsupported',
+  'relkind ' || c.relkind::text,
+  c.relname
+FROM
+  pg_class c
+  JOIN target ON c.relnamespace = target.nsp
+WHERE
+  -- 'i' and 'I' are censused through pg_index, 't' is an internal TOAST table.
+  c.relkind NOT IN ('r', 'p', 'v', 'm', 'f', 'S', 'c', 'i', 'I', 't')
+UNION ALL
+SELECT
+  'unsupported',
+  'typtype ' || t.typtype::text,
+  t.typname
+FROM
+  pg_type t
+  JOIN target ON t.typnamespace = target.nsp
+WHERE
+  t.typtype NOT IN ('e', 'd', 'c')
+  -- An array type is implied by its element type, a row type by its relation.
+  AND t.typcategory <> 'A'
+  AND NOT EXISTS (
+    SELECT
+    FROM
+      pg_class c
+    WHERE
+      c.reltype = t.oid
+  )
+  AND NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = t.oid
+      AND e.classid = 'pg_type'::regclass
+  )
+UNION ALL
+SELECT
+  'unsupported',
+  'aggregate',
+  p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')'
+FROM
+  pg_proc p
+  JOIN target ON p.pronamespace = target.nsp
+WHERE
+  -- An aggregate's behaviour lives in pg_aggregate, not in the prosrc the routine class hashes.
+  p.prokind = 'a'
+  AND NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = p.oid
+      AND e.classid = 'pg_proc'::regclass
+  )
+UNION ALL
+SELECT
+  'unsupported',
+  'operator',
+  op.oprname
+FROM
+  pg_operator op
+  JOIN target ON op.oprnamespace = target.nsp
+WHERE
+  NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = op.oid
+      AND e.classid = 'pg_operator'::regclass
+  )
+UNION ALL
+SELECT
+  'unsupported',
+  'operator class',
+  opc.opcname
+FROM
+  pg_opclass opc
+  JOIN target ON opc.opcnamespace = target.nsp
+WHERE
+  NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = opc.oid
+      AND e.classid = 'pg_opclass'::regclass
+  )
+UNION ALL
+SELECT
+  'unsupported',
+  'text search configuration',
+  cfg.cfgname
+FROM
+  pg_ts_config cfg
+  JOIN target ON cfg.cfgnamespace = target.nsp
+WHERE
+  NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = cfg.oid
+      AND e.classid = 'pg_ts_config'::regclass
+  )
+UNION ALL
+SELECT
+  'unsupported',
+  'conversion',
+  conv.conname
+FROM
+  pg_conversion conv
+  JOIN target ON conv.connamespace = target.nsp
+WHERE
+  NOT EXISTS (
+    SELECT
+    FROM
+      extension_owned e
+    WHERE
+      e.objid = conv.oid
+      AND e.classid = 'pg_conversion'::regclass
+  )
+ORDER BY
+  1,
+  2,
+  3;

--- a/postgres/census.sql
+++ b/postgres/census.sql
@@ -32,7 +32,8 @@ WITH
       pg_namespace
     WHERE
       nspname = ?0
-  )
+  ),
+  census AS (
 SELECT
   'column' AS class,
   c.relname || '.' || a.attname AS identity,
@@ -136,9 +137,9 @@ UNION ALL
 SELECT
   'routine',
   p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')',
-  -- The body is hashed rather than embedded: a routine definition can run to hundreds of lines,
-  -- and the census is read as a diff where one changed line beats one changed page.
-  p.prokind::text || ' ' || md5(coalesce(p.prosrc, '')) || ' ' || pg_get_function_result(p.oid) || ' ' || p.provolatile::text || ' ' || p.proisstrict::text || ' ' || p.prosecdef::text || ' ' || l.lanname
+  -- The complete reconstructed definition is hashed rather than embedded: it can run to hundreds
+  -- of lines, and the census is read as a diff where one changed line beats one changed page.
+  p.prokind::text || ' ' || md5(pg_get_functiondef(p.oid)) || ' ' || pg_get_function_result(p.oid) || ' ' || p.provolatile::text || ' ' || p.proisstrict::text || ' ' || p.prosecdef::text || ' ' || l.lanname
 FROM
   pg_proc p
   JOIN target ON p.pronamespace = target.nsp
@@ -157,7 +158,7 @@ UNION ALL
 SELECT
   'trigger',
   c.relname || '.' || tg.tgname,
-  pg_get_triggerdef(tg.oid)
+  pg_get_triggerdef(tg.oid) || ' ENABLED ' || tg.tgenabled::text
 FROM
   pg_trigger tg
   JOIN pg_class c ON c.oid = tg.tgrelid
@@ -168,7 +169,17 @@ UNION ALL
 SELECT
   'policy',
   c.relname || '.' || pol.polname,
-  pol.polcmd::text || ' ' || coalesce(pg_get_expr(pol.polqual, pol.polrelid), '-') || ' ' || coalesce(pg_get_expr(pol.polwithcheck, pol.polrelid), '-')
+  pol.polcmd::text || ' ' || pol.polpermissive::text || ' ' || array_to_string(
+    ARRAY(
+      SELECT
+        CASE WHEN role_oid = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(role_oid) END
+      FROM
+        unnest(pol.polroles) AS roles (role_oid)
+      ORDER BY
+        1
+    ),
+    ','
+  ) || ' ' || coalesce(pg_get_expr(pol.polqual, pol.polrelid), '-') || ' ' || coalesce(pg_get_expr(pol.polwithcheck, pol.polrelid), '-')
 FROM
   pg_policy pol
   JOIN pg_class c ON c.oid = pol.polrelid
@@ -396,7 +407,24 @@ WHERE
       e.objid = conv.oid
       AND e.classid = 'pg_conversion'::regclass
   )
+  )
+SELECT
+  CASE
+    WHEN class IN ('relation', 'index') THEN 'pg_class'
+    WHEN class = 'constraint' THEN 'pg_constraint'
+    WHEN class = 'type' THEN 'pg_type'
+    WHEN class = 'routine' THEN 'pg_proc'
+    WHEN class = 'unsupported' AND identity LIKE 'relkind %' THEN 'pg_class'
+    WHEN class = 'unsupported' AND identity LIKE 'typtype %' THEN 'pg_type'
+    WHEN class = 'unsupported' AND identity = 'aggregate' THEN 'pg_proc'
+    ELSE ''
+  END AS catalog,
+  class,
+  identity,
+  definition
+FROM
+  census
 ORDER BY
-  1,
   2,
-  3;
+  3,
+  4;

--- a/postgres/census.sql
+++ b/postgres/census.sql
@@ -1,21 +1,10 @@
--- A canonical, order-insensitive census of a schema, one row per object as
--- (class, identity, definition).
---
--- Definitions are rendered by PostgreSQL itself through the pg_get_*def family — the same
--- functions pg_dump uses — so however a migration spelled a thing, the catalog reports one
--- canonical form. Rows are keyed by object identity rather than ordinal position, which is what
--- lets a column re-added at the end of a table by a rollback read as identical.
---
--- Nothing derives from an OID. OIDs are assigned in creation order, so any leak would make an
--- identical schema built by a different sequence of statements render different text.
---
--- Classes this census cannot render emit an 'unsupported' row instead of being skipped, turning a
--- gap in coverage into a loud failure rather than a silent pass.
+-- Canonical (class, identity, definition) rows for one schema.
+-- PostgreSQL renders definitions; identity keys make comparison order-insensitive.
+-- Output is OID-free. Unsupported classes fail instead of disappearing.
 --
 -- ?0 is the schema to census.
 WITH
-  -- Objects a CREATE EXTENSION brought in belong to the extension, which is censused in its own
-  -- right, so dropping its members here loses no coverage.
+  -- Extension members are represented by their owning extension.
   extension_owned AS (
     SELECT
       objid,
@@ -48,7 +37,7 @@ FROM
 WHERE
   a.attnum > 0
   AND NOT a.attisdropped
-  -- 'c' covers the fields of a standalone composite type, which has no other home.
+  -- Include standalone composite fields.
   AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'c')
 UNION ALL
 SELECT
@@ -115,8 +104,7 @@ FROM
   JOIN target ON t.typnamespace = target.nsp
 WHERE
   t.typtype IN ('e', 'd', 'c')
-  -- A table's row type is implied by the table. A standalone composite type also owns a pg_class
-  -- row, of relkind 'c', which is why only the other kinds are excluded here.
+  -- Table row types are implied; standalone composites (relkind 'c') are not.
   AND NOT EXISTS (
     SELECT
     FROM
@@ -137,8 +125,7 @@ UNION ALL
 SELECT
   'routine',
   p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')',
-  -- The complete reconstructed definition is hashed rather than embedded: it can run to hundreds
-  -- of lines, and the census is read as a diff where one changed line beats one changed page.
+  -- Hash complete definitions to preserve one-line records.
   p.prokind::text || ' ' || md5(pg_get_functiondef(p.oid)) || ' ' || pg_get_function_result(p.oid) || ' ' || p.provolatile::text || ' ' || p.proisstrict::text || ' ' || p.prosecdef::text || ' ' || l.lanname
 FROM
   pg_proc p
@@ -280,8 +267,7 @@ FROM
 WHERE
   n.nspname NOT LIKE 'pg\_%'
   AND n.nspname <> 'information_schema'
-  -- Everything below reports what this census cannot render. A row here fails the caller rather
-  -- than letting an object class drop silently out of coverage.
+  -- Unsupported objects fail the snapshot instead of disappearing.
 UNION ALL
 SELECT
   'unsupported',

--- a/postgres/censusCoverage.sql
+++ b/postgres/censusCoverage.sql
@@ -1,6 +1,5 @@
--- Expected row counts for the four PostgreSQL catalogs the census promises to cover completely.
--- census.sql tags each corresponding output row with its source catalog; comparing the totals
--- makes removing or accidentally filtering any renderer branch fail loudly.
+-- Independent object counts for the four catalogs the census covers completely.
+-- census.sql tags matching rows by source catalog; unequal totals expose a missing renderer.
 --
 -- ?0 is the schema to census.
 WITH
@@ -29,7 +28,6 @@ WITH
       nspname = ?0
   ),
   catalog_objects (catalog, oid) AS (
-    -- Supported relations each produce one 'relation' row.
     SELECT
       'pg_class',
       c.oid
@@ -47,7 +45,6 @@ WITH
           AND e.classid = 'pg_class'::regclass
       )
     UNION ALL
-    -- Index relations each produce one 'index' row.
     SELECT
       'pg_class',
       i.indexrelid
@@ -56,7 +53,6 @@ WITH
       JOIN pg_class c ON c.oid = i.indexrelid
       JOIN target ON c.relnamespace = target.nsp
     UNION ALL
-    -- Every remaining user-defined relation kind produces an 'unsupported' row.
     SELECT
       'pg_class',
       c.oid
@@ -73,7 +69,6 @@ WITH
       pg_constraint con
       JOIN target ON con.connamespace = target.nsp
     UNION ALL
-    -- Supported enum, domain, and standalone composite types each produce one 'type' row.
     SELECT
       'pg_type',
       t.oid
@@ -99,7 +94,6 @@ WITH
           AND e.classid = 'pg_type'::regclass
       )
     UNION ALL
-    -- Non-implied types outside that supported set each produce an 'unsupported' row.
     SELECT
       'pg_type',
       t.oid
@@ -125,7 +119,6 @@ WITH
           AND e.classid = 'pg_type'::regclass
       )
     UNION ALL
-    -- Regular routines produce 'routine' rows; aggregates produce 'unsupported' rows.
     SELECT
       'pg_proc',
       p.oid

--- a/postgres/censusCoverage.sql
+++ b/postgres/censusCoverage.sql
@@ -1,0 +1,154 @@
+-- Expected row counts for the four PostgreSQL catalogs the census promises to cover completely.
+-- census.sql tags each corresponding output row with its source catalog; comparing the totals
+-- makes removing or accidentally filtering any renderer branch fail loudly.
+--
+-- ?0 is the schema to census.
+WITH
+  catalogs (catalog) AS (
+    VALUES
+      ('pg_class'),
+      ('pg_constraint'),
+      ('pg_type'),
+      ('pg_proc')
+  ),
+  extension_owned AS (
+    SELECT
+      objid,
+      classid
+    FROM
+      pg_depend
+    WHERE
+      deptype = 'e'
+  ),
+  target AS (
+    SELECT
+      oid AS nsp
+    FROM
+      pg_namespace
+    WHERE
+      nspname = ?0
+  ),
+  catalog_objects (catalog, oid) AS (
+    -- Supported relations each produce one 'relation' row.
+    SELECT
+      'pg_class',
+      c.oid
+    FROM
+      pg_class c
+      JOIN target ON c.relnamespace = target.nsp
+    WHERE
+      c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S', 'c')
+      AND NOT EXISTS (
+        SELECT
+        FROM
+          extension_owned e
+        WHERE
+          e.objid = c.oid
+          AND e.classid = 'pg_class'::regclass
+      )
+    UNION ALL
+    -- Index relations each produce one 'index' row.
+    SELECT
+      'pg_class',
+      i.indexrelid
+    FROM
+      pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN target ON c.relnamespace = target.nsp
+    UNION ALL
+    -- Every remaining user-defined relation kind produces an 'unsupported' row.
+    SELECT
+      'pg_class',
+      c.oid
+    FROM
+      pg_class c
+      JOIN target ON c.relnamespace = target.nsp
+    WHERE
+      c.relkind NOT IN ('r', 'p', 'v', 'm', 'f', 'S', 'c', 'i', 'I', 't')
+    UNION ALL
+    SELECT
+      'pg_constraint',
+      con.oid
+    FROM
+      pg_constraint con
+      JOIN target ON con.connamespace = target.nsp
+    UNION ALL
+    -- Supported enum, domain, and standalone composite types each produce one 'type' row.
+    SELECT
+      'pg_type',
+      t.oid
+    FROM
+      pg_type t
+      JOIN target ON t.typnamespace = target.nsp
+    WHERE
+      t.typtype IN ('e', 'd', 'c')
+      AND NOT EXISTS (
+        SELECT
+        FROM
+          pg_class c
+        WHERE
+          c.reltype = t.oid
+          AND c.relkind <> 'c'
+      )
+      AND NOT EXISTS (
+        SELECT
+        FROM
+          extension_owned e
+        WHERE
+          e.objid = t.oid
+          AND e.classid = 'pg_type'::regclass
+      )
+    UNION ALL
+    -- Non-implied types outside that supported set each produce an 'unsupported' row.
+    SELECT
+      'pg_type',
+      t.oid
+    FROM
+      pg_type t
+      JOIN target ON t.typnamespace = target.nsp
+    WHERE
+      t.typtype NOT IN ('e', 'd', 'c')
+      AND t.typcategory <> 'A'
+      AND NOT EXISTS (
+        SELECT
+        FROM
+          pg_class c
+        WHERE
+          c.reltype = t.oid
+      )
+      AND NOT EXISTS (
+        SELECT
+        FROM
+          extension_owned e
+        WHERE
+          e.objid = t.oid
+          AND e.classid = 'pg_type'::regclass
+      )
+    UNION ALL
+    -- Regular routines produce 'routine' rows; aggregates produce 'unsupported' rows.
+    SELECT
+      'pg_proc',
+      p.oid
+    FROM
+      pg_proc p
+      JOIN target ON p.pronamespace = target.nsp
+    WHERE
+      NOT EXISTS (
+        SELECT
+        FROM
+          extension_owned e
+        WHERE
+          e.objid = p.oid
+          AND e.classid = 'pg_proc'::regclass
+      )
+  )
+SELECT
+  catalogs.catalog,
+  count(catalog_objects.oid) AS expected
+FROM
+  catalogs
+  LEFT JOIN catalog_objects USING (catalog)
+GROUP BY
+  catalogs.catalog
+ORDER BY
+  1;

--- a/postgres/census_internal_test.go
+++ b/postgres/census_internal_test.go
@@ -1,0 +1,67 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCensusCoverage(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+
+		rows     []censusRow
+		coverage []censusCoverageRow
+
+		expectError string
+	}{
+		{
+			name: "Success",
+			rows: []censusRow{
+				{Catalog: "pg_class", Class: censusClassRelation},
+				{Catalog: "pg_class", Class: "unsupported"},
+				{Catalog: "pg_proc", Class: "routine"},
+				{Class: "trigger"},
+			},
+			coverage: []censusCoverageRow{
+				{Catalog: "pg_class", Expected: 2},
+				{Catalog: "pg_proc", Expected: 1},
+			},
+		},
+		{
+			name: "Error/ClassMissing",
+			rows: []censusRow{
+				{Catalog: "pg_proc", Class: "routine"},
+			},
+			coverage: []censusCoverageRow{
+				{Catalog: "pg_class", Expected: 1},
+				{Catalog: "pg_proc", Expected: 1},
+			},
+			expectError: "coverage for pg_class: rendered 0 objects, catalog has 1",
+		},
+		{
+			name: "Error/ClassOvercounted",
+			rows: []censusRow{
+				{Catalog: "pg_class", Class: censusClassRelation},
+				{Catalog: "pg_class", Class: censusClassRelation},
+			},
+			coverage:    []censusCoverageRow{{Catalog: "pg_class", Expected: 1}},
+			expectError: "coverage for pg_class: rendered 2 objects, catalog has 1",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateCensusCoverage(testCase.rows, testCase.coverage)
+			if testCase.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, testCase.expectError)
+			}
+		})
+	}
+}

--- a/postgres/census_test.go
+++ b/postgres/census_test.go
@@ -1,0 +1,331 @@
+package postgres_test
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+	"github.com/uptrace/bun/driver/pgdriver"
+
+	"github.com/a-novel-kit/golib/postgres"
+)
+
+// probeDB stands up an empty database, runs statements against it, and drops it on cleanup.
+//
+// Each probe gets a database rather than a schema because the census covers extensions, which are
+// database-scoped: two schemas of one database would agree about them however the probe differed.
+func probeDB(t *testing.T, statements ...string) *bun.DB {
+	t.Helper()
+
+	dsn := os.Getenv("POSTGRES_DSN")
+	require.NotEmpty(t, dsn,
+		"POSTGRES_DSN must point at a throwaway database — the census reads a real catalog")
+
+	name := "census_probe_" + strings.ToLower(rand.Text())
+
+	open := func(options ...pgdriver.Option) *bun.DB {
+		return bun.NewDB(sql.OpenDB(pgdriver.NewConnector(options...)), pgdialect.New())
+	}
+
+	maintenance := open(pgdriver.WithDSN(dsn))
+
+	ctx := t.Context()
+
+	_, err := maintenance.NewRaw("CREATE DATABASE ?", bun.Ident(name)).Exec(ctx)
+	require.NoError(t, err, "create the probe database")
+
+	t.Cleanup(func() {
+		// t.Context is already cancelled by the time cleanups run.
+		cleanup := open(pgdriver.WithDSN(dsn))
+		defer func() { _ = cleanup.Close() }()
+
+		_, _ = cleanup.NewRaw(
+			"DROP DATABASE IF EXISTS ? WITH (FORCE)", bun.Ident(name),
+		).Exec(context.Background())
+	})
+
+	require.NoError(t, maintenance.Close())
+
+	db := open(pgdriver.WithDSN(dsn), pgdriver.WithDatabase(name))
+
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, statement := range statements {
+		_, err = db.NewRaw(statement).Exec(ctx)
+		require.NoErrorf(t, err, "probe statement %q", statement)
+	}
+
+	return db
+}
+
+// probeSnapshot censuses a database built from statements.
+func probeSnapshot(t *testing.T, statements ...string) string {
+	t.Helper()
+
+	snapshot, err := postgres.SchemaSnapshot(t.Context(), probeDB(t, statements...), "public")
+	require.NoError(t, err)
+
+	return snapshot
+}
+
+// drift is one pair of schemas the census must tell apart, or must not.
+type drift struct {
+	name string
+	from []string
+	to   []string
+}
+
+// A rollback that overshoots or stops short leaves the schema subtly wrong. Every case here is a
+// difference the census has to report, or a down migration could pass while leaving it behind.
+func TestSchemaSnapshotReportsDrift(t *testing.T) {
+	t.Parallel()
+
+	cases := []drift{
+		{
+			name: "table storage parameters not reset",
+			from: []string{`CREATE TABLE t (a int)`, `ALTER TABLE t SET (autovacuum_vacuum_scale_factor = 0.02)`},
+			to:   []string{`CREATE TABLE t (a int)`},
+		},
+		{
+			name: "NOT NULL lost",
+			from: []string{`CREATE TABLE t (a int NOT NULL)`},
+			to:   []string{`CREATE TABLE t (a int)`},
+		},
+		{
+			name: "column default lost",
+			from: []string{`CREATE TABLE t (a int NOT NULL DEFAULT 4)`},
+			to:   []string{`CREATE TABLE t (a int NOT NULL)`},
+		},
+		{
+			name: "index predicate widened",
+			from: []string{`CREATE TABLE t (a int, s text)`, `CREATE INDEX i ON t (a) WHERE s = 'x'`},
+			to:   []string{`CREATE TABLE t (a int, s text)`, `CREATE INDEX i ON t (a)`},
+		},
+		{
+			name: "index sort order lost",
+			from: []string{`CREATE TABLE t (a int)`, `CREATE INDEX i ON t (a DESC)`},
+			to:   []string{`CREATE TABLE t (a int)`, `CREATE INDEX i ON t (a)`},
+		},
+		{
+			name: "column comment lost",
+			from: []string{`CREATE TABLE t (a int)`, `COMMENT ON COLUMN t.a IS 'why'`},
+			to:   []string{`CREATE TABLE t (a int)`},
+		},
+		{
+			name: "enum label order changed",
+			from: []string{`CREATE TYPE e AS ENUM ('a', 'b')`},
+			to:   []string{`CREATE TYPE e AS ENUM ('b', 'a')`},
+		},
+		{
+			name: "enum value left behind",
+			from: []string{`CREATE TYPE e AS ENUM ('a', 'b')`},
+			to:   []string{`CREATE TYPE e AS ENUM ('a', 'b', 'c')`},
+		},
+		{
+			name: "foreign key action changed",
+			from: []string{`CREATE TABLE p (id int PRIMARY KEY)`, `CREATE TABLE t (p int REFERENCES p (id) ON DELETE CASCADE)`},
+			to:   []string{`CREATE TABLE p (id int PRIMARY KEY)`, `CREATE TABLE t (p int REFERENCES p (id))`},
+		},
+		{
+			name: "function body changed",
+			from: []string{`CREATE FUNCTION f() RETURNS int LANGUAGE sql AS $$ SELECT 1 $$`},
+			to:   []string{`CREATE FUNCTION f() RETURNS int LANGUAGE sql AS $$ SELECT 2 $$`},
+		},
+		{
+			name: "trigger left behind",
+			from: []string{`CREATE TABLE t (a int)`},
+			to: []string{
+				`CREATE TABLE t (a int)`,
+				`CREATE FUNCTION f() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$`,
+				`CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW EXECUTE FUNCTION f()`,
+			},
+		},
+		{
+			name: "view left behind",
+			from: []string{`CREATE TABLE t (a int)`},
+			to:   []string{`CREATE TABLE t (a int)`, `CREATE VIEW v AS SELECT a FROM t`},
+		},
+		{
+			name: "materialized view left behind",
+			from: []string{`CREATE TABLE t (a int)`},
+			to:   []string{`CREATE TABLE t (a int)`, `CREATE MATERIALIZED VIEW mv AS SELECT a FROM t`},
+		},
+		{
+			name: "sequence left behind",
+			from: []string{`CREATE TABLE t (a int)`},
+			to:   []string{`CREATE TABLE t (a int)`, `CREATE SEQUENCE s`},
+		},
+		{
+			name: "extension left behind",
+			from: []string{`CREATE TABLE t (a int)`},
+			to:   []string{`CREATE TABLE t (a int)`, `CREATE EXTENSION IF NOT EXISTS pg_trgm`},
+		},
+		{
+			name: "row level security left enabled",
+			from: []string{`CREATE TABLE t (a int)`},
+			to: []string{
+				`CREATE TABLE t (a int)`,
+				`ALTER TABLE t ENABLE ROW LEVEL SECURITY`,
+				`CREATE POLICY p ON t USING (a > 0)`,
+			},
+		},
+		{
+			name: "grant left behind",
+			from: []string{`CREATE TABLE t (a int)`},
+			to:   []string{`CREATE TABLE t (a int)`, `GRANT SELECT ON t TO PUBLIC`},
+		},
+		{
+			name: "extended statistics left behind",
+			from: []string{`CREATE TABLE t (a int, b int)`},
+			to:   []string{`CREATE TABLE t (a int, b int)`, `CREATE STATISTICS st ON a, b FROM t`},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			delta := postgres.SnapshotDelta(
+				probeSnapshot(t, testCase.from...),
+				probeSnapshot(t, testCase.to...),
+			)
+			require.NotEmpty(t, delta, "the census must report this difference")
+		})
+	}
+}
+
+// The census is only usable as a rollback oracle if it stays quiet about differences that are not
+// schema differences. Each case here is one a textual pg_dump comparison reports and this must not.
+func TestSchemaSnapshotIgnoresNonDifferences(t *testing.T) {
+	t.Parallel()
+
+	cases := []drift{
+		{
+			// The case that defeats a dump diff: PostgreSQL appends a re-added column rather than
+			// restoring its position, so a correct rollback still moves it.
+			name: "column re-added at the end by a rollback",
+			from: []string{`CREATE TABLE t (a int, b int, c int)`},
+			to: []string{
+				`CREATE TABLE t (a int, b int, c int)`,
+				`ALTER TABLE t DROP COLUMN b`,
+				`ALTER TABLE t ADD COLUMN b int`,
+			},
+		},
+		{
+			name: "tables created in a different order",
+			from: []string{`CREATE TABLE b (x int)`, `CREATE TABLE a (x int)`},
+			to:   []string{`CREATE TABLE a (x int)`, `CREATE TABLE b (x int)`},
+		},
+		{
+			name: "rows present",
+			from: []string{`CREATE TABLE t (a int)`},
+			to:   []string{`CREATE TABLE t (a int)`, `INSERT INTO t VALUES (1)`},
+		},
+		{
+			name: "constraint spelled inline versus named",
+			from: []string{`CREATE TABLE t (a int PRIMARY KEY)`},
+			to:   []string{`CREATE TABLE t (a int)`, `ALTER TABLE t ADD PRIMARY KEY (a)`},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			delta := postgres.SnapshotDelta(
+				probeSnapshot(t, testCase.from...),
+				probeSnapshot(t, testCase.to...),
+			)
+			require.Empty(t, delta, "the census must treat these schemas as identical")
+		})
+	}
+}
+
+// PostgreSQL assigns OIDs in creation order. If any reached the snapshot, an identical schema built
+// by a different sequence of statements would render differently and every committed snapshot would
+// churn for no reason — so the two halves here are deliberately built in opposite orders.
+func TestSchemaSnapshotIsIndependentOfCreationOrder(t *testing.T) {
+	t.Parallel()
+
+	first := []string{
+		`CREATE TYPE st AS ENUM ('a', 'b')`,
+		`CREATE TABLE t (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), s st NOT NULL)`,
+		`CREATE UNIQUE INDEX ti ON t (s) WHERE s = 'a'`,
+	}
+	second := []string{
+		`CREATE TABLE other (id int PRIMARY KEY)`,
+		`CREATE FUNCTION f() RETURNS int LANGUAGE sql AS $$ SELECT 1 $$`,
+		`CREATE SEQUENCE sq`,
+	}
+	comments := []string{
+		`COMMENT ON TABLE t IS 'a table'`,
+		`COMMENT ON COLUMN t.s IS 'a column'`,
+		`COMMENT ON TYPE st IS 'a type'`,
+		`COMMENT ON SCHEMA public IS 'a schema'`,
+		`COMMENT ON FUNCTION f() IS 'a function'`,
+	}
+
+	forward := probeSnapshot(t, append(append(append([]string{}, first...), second...), comments...)...)
+	reversed := probeSnapshot(t, append(append(append([]string{}, second...), first...), comments...)...)
+
+	require.Equal(t, forward, reversed, "the snapshot must not depend on the order objects were created in")
+}
+
+// An object class the census cannot render must fail the caller. Silently omitting it would make a
+// snapshot taken after it was created compare equal to one taken before — the exact blindness the
+// snapshot exists to rule out.
+func TestSchemaSnapshotRejectsUnsupportedObjects(t *testing.T) {
+	t.Parallel()
+
+	db := probeDB(t,
+		`CREATE FUNCTION addint(int, int) RETURNS int LANGUAGE sql IMMUTABLE AS $$ SELECT $1 + $2 $$`,
+		`CREATE AGGREGATE total (int) (SFUNC = addint, STYPE = int, INITCOND = '0')`,
+	)
+
+	_, err := postgres.SchemaSnapshot(t.Context(), db, "public")
+	require.ErrorIs(t, err, postgres.ErrUnsupportedSchemaObject)
+	require.Contains(t, err.Error(), "aggregate")
+}
+
+// The migrator's own bookkeeping exists at every step of a rollback and describes the harness, not
+// the schema under test, so it must never reach a snapshot.
+func TestSchemaSnapshotExcludesMigrationBookkeeping(t *testing.T) {
+	t.Parallel()
+
+	bare := probeSnapshot(t, `CREATE TABLE t (a int)`)
+	withBookkeeping := probeSnapshot(t,
+		`CREATE TABLE t (a int)`,
+		`CREATE TABLE bun_migrations (id bigserial PRIMARY KEY, name varchar(500), group_id bigint)`,
+		`CREATE TABLE bun_migration_locks (id bigserial PRIMARY KEY, table_name varchar(500))`,
+	)
+
+	require.Equal(t, bare, withBookkeeping)
+}
+
+func TestSnapshotDelta(t *testing.T) {
+	t.Parallel()
+
+	t.Run("identical snapshots have no delta", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, postgres.SnapshotDelta("a\nb\n", "b\na\n"))
+	})
+
+	t.Run("reports both directions, sorted", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t,
+			[]string{"missing: gone", "unexpected: added"},
+			postgres.SnapshotDelta("kept\ngone\n", "kept\nadded\n"))
+	})
+
+	t.Run("an empty snapshot against a populated one", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, []string{"unexpected: only"}, postgres.SnapshotDelta("", "only\n"))
+	})
+}

--- a/postgres/census_test.go
+++ b/postgres/census_test.go
@@ -138,12 +138,31 @@ func TestSchemaSnapshotReportsDrift(t *testing.T) {
 			to:   []string{`CREATE FUNCTION f() RETURNS int LANGUAGE sql AS $$ SELECT 2 $$`},
 		},
 		{
+			name: "function setting changed",
+			from: []string{`CREATE FUNCTION f() RETURNS int LANGUAGE sql SET search_path = public AS $$ SELECT 1 $$`},
+			to:   []string{`CREATE FUNCTION f() RETURNS int LANGUAGE sql AS $$ SELECT 1 $$`},
+		},
+		{
 			name: "trigger left behind",
 			from: []string{`CREATE TABLE t (a int)`},
 			to: []string{
 				`CREATE TABLE t (a int)`,
 				`CREATE FUNCTION f() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$`,
 				`CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW EXECUTE FUNCTION f()`,
+			},
+		},
+		{
+			name: "trigger disabled",
+			from: []string{
+				`CREATE TABLE t (a int)`,
+				`CREATE FUNCTION f() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$`,
+				`CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW EXECUTE FUNCTION f()`,
+			},
+			to: []string{
+				`CREATE TABLE t (a int)`,
+				`CREATE FUNCTION f() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$`,
+				`CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW EXECUTE FUNCTION f()`,
+				`ALTER TABLE t DISABLE TRIGGER tr`,
 			},
 		},
 		{
@@ -173,6 +192,19 @@ func TestSchemaSnapshotReportsDrift(t *testing.T) {
 				`CREATE TABLE t (a int)`,
 				`ALTER TABLE t ENABLE ROW LEVEL SECURITY`,
 				`CREATE POLICY p ON t USING (a > 0)`,
+			},
+		},
+		{
+			name: "row level security policy role changed",
+			from: []string{
+				`CREATE TABLE t (a int)`,
+				`ALTER TABLE t ENABLE ROW LEVEL SECURITY`,
+				`CREATE POLICY p ON t TO PUBLIC USING (a > 0)`,
+			},
+			to: []string{
+				`CREATE TABLE t (a int)`,
+				`ALTER TABLE t ENABLE ROW LEVEL SECURITY`,
+				`CREATE POLICY p ON t TO pg_read_all_data USING (a > 0)`,
 			},
 		},
 		{
@@ -306,6 +338,33 @@ func TestSchemaSnapshotExcludesMigrationBookkeeping(t *testing.T) {
 	)
 
 	require.Equal(t, bare, withBookkeeping)
+}
+
+func TestSchemaSnapshotKeepsSimilarlyNamedUserObjects(t *testing.T) {
+	t.Parallel()
+
+	snapshot := probeSnapshot(t,
+		`CREATE TABLE bun_migrations_archive (id int PRIMARY KEY)`,
+	)
+
+	require.Contains(t, snapshot, "relation\tbun_migrations_archive\t")
+}
+
+func TestSchemaSnapshotEscapesRecordSeparators(t *testing.T) {
+	t.Parallel()
+
+	snapshot := probeSnapshot(t,
+		`CREATE TABLE t (a int)`,
+		`COMMENT ON TABLE t IS E'first\nsecond\tfield\\tail'`,
+	)
+
+	require.Contains(t, snapshot, `first\nsecond\tfield\\tail`)
+	require.NotContains(t, snapshot, "first\nsecond")
+
+	for line := range strings.SplitSeq(strings.TrimSuffix(snapshot, "\n"), "\n") {
+		require.Equalf(t, 2, strings.Count(line, "\t"),
+			"every snapshot record must have exactly three tab-separated fields: %q", line)
+	}
 }
 
 func TestSnapshotDelta(t *testing.T) {

--- a/postgres/census_test.go
+++ b/postgres/census_test.go
@@ -16,10 +16,7 @@ import (
 	"github.com/a-novel-kit/golib/postgres"
 )
 
-// probeDB stands up an empty database, runs statements against it, and drops it on cleanup.
-//
-// Each probe gets a database rather than a schema because the census covers extensions, which are
-// database-scoped: two schemas of one database would agree about them however the probe differed.
+// Use separate databases because extensions are database-scoped.
 func probeDB(t *testing.T, statements ...string) *bun.DB {
 	t.Helper()
 
@@ -64,7 +61,6 @@ func probeDB(t *testing.T, statements ...string) *bun.DB {
 	return db
 }
 
-// probeSnapshot censuses a database built from statements.
 func probeSnapshot(t *testing.T, statements ...string) string {
 	t.Helper()
 
@@ -74,15 +70,13 @@ func probeSnapshot(t *testing.T, statements ...string) string {
 	return snapshot
 }
 
-// drift is one pair of schemas the census must tell apart, or must not.
 type drift struct {
 	name string
 	from []string
 	to   []string
 }
 
-// A rollback that overshoots or stops short leaves the schema subtly wrong. Every case here is a
-// difference the census has to report, or a down migration could pass while leaving it behind.
+// Each case is schema drift a rollback must expose.
 func TestSchemaSnapshotReportsDrift(t *testing.T) {
 	t.Parallel()
 
@@ -232,15 +226,13 @@ func TestSchemaSnapshotReportsDrift(t *testing.T) {
 	}
 }
 
-// The census is only usable as a rollback oracle if it stays quiet about differences that are not
-// schema differences. Each case here is one a textual pg_dump comparison reports and this must not.
+// Each case is equivalent schema a textual dump can report as different.
 func TestSchemaSnapshotIgnoresNonDifferences(t *testing.T) {
 	t.Parallel()
 
 	cases := []drift{
 		{
-			// The case that defeats a dump diff: PostgreSQL appends a re-added column rather than
-			// restoring its position, so a correct rollback still moves it.
+			// PostgreSQL appends a re-added column; ordinal position is not schema drift.
 			name: "column re-added at the end by a rollback",
 			from: []string{`CREATE TABLE t (a int, b int, c int)`},
 			to: []string{
@@ -279,9 +271,7 @@ func TestSchemaSnapshotIgnoresNonDifferences(t *testing.T) {
 	}
 }
 
-// PostgreSQL assigns OIDs in creation order. If any reached the snapshot, an identical schema built
-// by a different sequence of statements would render differently and every committed snapshot would
-// churn for no reason — so the two halves here are deliberately built in opposite orders.
+// Opposite creation order detects leaked OIDs.
 func TestSchemaSnapshotIsIndependentOfCreationOrder(t *testing.T) {
 	t.Parallel()
 
@@ -309,9 +299,6 @@ func TestSchemaSnapshotIsIndependentOfCreationOrder(t *testing.T) {
 	require.Equal(t, forward, reversed, "the snapshot must not depend on the order objects were created in")
 }
 
-// An object class the census cannot render must fail the caller. Silently omitting it would make a
-// snapshot taken after it was created compare equal to one taken before — the exact blindness the
-// snapshot exists to rule out.
 func TestSchemaSnapshotRejectsUnsupportedObjects(t *testing.T) {
 	t.Parallel()
 
@@ -325,8 +312,6 @@ func TestSchemaSnapshotRejectsUnsupportedObjects(t *testing.T) {
 	require.Contains(t, err.Error(), "aggregate")
 }
 
-// The migrator's own bookkeeping exists at every step of a rollback and describes the harness, not
-// the schema under test, so it must never reach a snapshot.
 func TestSchemaSnapshotExcludesMigrationBookkeeping(t *testing.T) {
 	t.Parallel()
 

--- a/postgres/roundtrip.go
+++ b/postgres/roundtrip.go
@@ -18,65 +18,30 @@ import (
 )
 
 const (
-	// roundtripInstancePrefix names the throwaway database one roundtrip runs against. Unlike the
-	// databases RunDBTest clones, it starts empty: the run's whole subject is what the migrations
-	// do to a virgin database, so there is nothing to clone from.
 	roundtripInstancePrefix = "goroundtrip_"
 
-	// roundtripSnapshotExt is the extension of a committed snapshot. Plain text, because its
-	// review value is that a reader can see a migration's effect on the schema in a pull request.
 	roundtripSnapshotExt = ".txt"
 
-	// roundtripUpdateEnv, when set to any non-empty value, makes a run rewrite the committed
-	// snapshots instead of comparing against them.
-	//
-	// An environment variable rather than a test flag: this package is linked into every
-	// consumer's test binary, and a flag registered here would collide with a consumer that
-	// defines its own.
 	roundtripUpdateEnv = "GOLIB_UPDATE_SNAPSHOTS"
 
-	// roundtripSchema is the schema migrations land in. Services run one schema per database, so
-	// the roundtrip has no reason to take it as a parameter.
 	roundtripSchema = "public"
 )
 
-// errMigrationDrift reports that the schema is not where a migration should have left it. It stays
-// unexported because RunMigrationRoundtripTest fails the test rather than handing it back; only
-// this package's own tests distinguish it from an infrastructure failure.
 var errMigrationDrift = errors.New("schema drift")
 
-// RoundtripOptions tunes [RunMigrationRoundtripTest]. The zero value runs the roundtrip against a
-// schema that never holds rows and keeps no snapshots on disk.
+// RoundtripOptions configures [RunMigrationRoundtripTest]. Its zero value is valid.
 type RoundtripOptions struct {
-	// Fixtures holds SQL files named for the migration they follow, as `<timestamp>_<name>.sql`.
-	// A fixture runs after its migration, so its rows are what the next migration's up and its own
-	// migration's down both have to survive.
-	//
-	// Seeding at the step rather than at the end is what puts data in front of the up migrations
-	// too: a column added NOT NULL with no default succeeds on an empty table and fails on a
-	// populated one, and only the second is what production does.
-	//
-	// A migration with no matching file simply seeds nothing.
+	// Fixtures holds optional `<timestamp>_<name>.sql` files, applied after the named migration.
 	Fixtures fs.FS
 
-	// Snapshots is the directory holding one committed snapshot per migration. When set, each
-	// snapshot taken on the way up is compared against the file for that migration, so an edit to
-	// an already-merged migration surfaces as a diff on a file that should never move again.
-	//
-	// Setting GOLIB_UPDATE_SNAPSHOTS rewrites the files instead of comparing.
+	// Snapshots holds one committed snapshot per migration. GOLIB_UPDATE_SNAPSHOTS rewrites them.
 	Snapshots string
 }
 
 // RunMigrationRoundtripTest proves that every down migration exactly reverses its up.
 //
-// It applies the migrations one at a time against a throwaway database, snapshotting the schema
-// after each, then rolls them back one at a time and requires every rollback to land exactly on the
-// state before its migration. Finally it re-applies the whole set, which catches a down migration
-// that leaves the database in a state the up cannot run against a second time.
-//
-// Verifying each step, rather than only the end state, is what localises a failure to the migration
-// that caused it. A rollback that overshoots and one that stops short both end at the wrong place,
-// but the step that first diverged names which migration to fix.
+// It snapshots each up, verifies each down against the preceding snapshot, then re-applies the full
+// set. Fixtures run between steps; snapshots optionally enforce migration immutability.
 //
 // config must expose Options() []pgdriver.Option, as postgrespresets.Default does.
 func RunMigrationRoundtripTest(t *testing.T, config Config, migrations fs.FS, opts *RoundtripOptions) {
@@ -85,9 +50,6 @@ func RunMigrationRoundtripTest(t *testing.T, config Config, migrations fs.FS, op
 	require.NoError(t, verifyRoundtrip(t.Context(), roundtripDatabase(t, config), migrations, opts))
 }
 
-// verifyRoundtrip carries the whole roundtrip. It returns errors rather than failing a test so that
-// this package can test what it does when a migration set is broken, which is the behaviour that
-// matters most.
 func verifyRoundtrip(ctx context.Context, db *bun.DB, migrations fs.FS, opts *RoundtripOptions) error {
 	if opts == nil {
 		opts = &RoundtripOptions{}
@@ -138,8 +100,7 @@ func verifyRoundtrip(ctx context.Context, db *bun.DB, migrations fs.FS, opts *Ro
 	for step := len(ordered); step >= 1; step-- {
 		err = roundtripDown(ctx, db, ordered, step, states[step-1])
 		if err != nil {
-			// Drift cascades: every remaining rollback would report the same difference, so the
-			// run stops at the migration that introduced it rather than repeating itself.
+			// Later rollback errors would only repeat this first divergence.
 			return err
 		}
 	}
@@ -147,7 +108,6 @@ func verifyRoundtrip(ctx context.Context, db *bun.DB, migrations fs.FS, opts *Ro
 	return roundtripReplay(ctx, db, ordered, states[len(ordered)])
 }
 
-// roundtripUp applies migration number step and nothing else, and snapshots the result.
 func roundtripUp(ctx context.Context, db *bun.DB, ordered migrate.MigrationSlice, step int) (string, error) {
 	slug := roundtripSlug(ordered[step-1])
 
@@ -165,7 +125,6 @@ func roundtripUp(ctx context.Context, db *bun.DB, ordered migrate.MigrationSlice
 	return SchemaSnapshot(ctx, db, roundtripSchema)
 }
 
-// roundtripDown rolls back migration number step and requires the schema to land on want.
 func roundtripDown(
 	ctx context.Context, db *bun.DB, ordered migrate.MigrationSlice, step int, want string,
 ) error {
@@ -194,8 +153,6 @@ func roundtripDown(
 	return nil
 }
 
-// roundtripReplay re-applies every migration to the rolled-back database and requires the schema to
-// come back identical.
 func roundtripReplay(ctx context.Context, db *bun.DB, ordered migrate.MigrationSlice, want string) error {
 	_, err := migrate.NewMigrator(db, roundtripPrefix(ordered, len(ordered))).Migrate(ctx)
 	if err != nil {
@@ -216,12 +173,8 @@ func roundtripReplay(ctx context.Context, db *bun.DB, ordered migrate.MigrationS
 	return nil
 }
 
-// roundtripPrefix builds a migration set holding only the first n of ordered.
-//
 // Bun stamps every migration applied by one Migrate call with a single group id, and rolls back a
-// whole group at a time. A set that ends at migration n therefore leaves exactly one migration
-// pending, which is what makes its group one migration wide — and a rollback of that group revert
-// one migration rather than the entire set.
+// whole group. Limiting the set to n leaves one pending migration per call.
 func roundtripPrefix(ordered migrate.MigrationSlice, n int) *migrate.Migrations {
 	set := migrate.NewMigrations()
 	for _, migration := range ordered[:n] {
@@ -231,9 +184,7 @@ func roundtripPrefix(ordered migrate.MigrationSlice, n int) *migrate.Migrations 
 	return set
 }
 
-// roundtripSlug rebuilds the stem of a migration's filename, which is how its fixture and its
-// committed snapshot are named. Bun splits the filename into a timestamp and a comment; neither
-// half identifies a migration on its own.
+// roundtripSlug rebuilds the filename stem Bun split during discovery.
 func roundtripSlug(migration migrate.Migration) string {
 	if migration.Comment == "" {
 		return migration.Name
@@ -242,7 +193,6 @@ func roundtripSlug(migration migrate.Migration) string {
 	return migration.Name + "_" + migration.Comment
 }
 
-// roundtripApplyFixture runs the fixture belonging to a migration, if there is one.
 func roundtripApplyFixture(
 	ctx context.Context, db *bun.DB, opts *RoundtripOptions, migration migrate.Migration,
 ) error {
@@ -254,8 +204,6 @@ func roundtripApplyFixture(
 
 	body, err := fs.ReadFile(opts.Fixtures, name)
 	if err != nil {
-		// A migration that needs no rows of its own is the common case, so an absent fixture is
-		// not a failure. Any other read error is.
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
@@ -271,8 +219,6 @@ func roundtripApplyFixture(
 	return nil
 }
 
-// roundtripCheckSnapshot compares a snapshot against its committed file, or rewrites the file when
-// the update variable is set.
 func roundtripCheckSnapshot(opts *RoundtripOptions, migration migrate.Migration, got string) error {
 	if opts.Snapshots == "" {
 		return nil
@@ -310,7 +256,6 @@ func roundtripCheckSnapshot(opts *RoundtripOptions, migration migrate.Migration,
 	return nil
 }
 
-// roundtripDatabase creates an empty database for one roundtrip and drops it on cleanup.
 func roundtripDatabase(t *testing.T, config Config) *bun.DB {
 	t.Helper()
 
@@ -325,7 +270,6 @@ func roundtripDatabase(t *testing.T, config Config) *bun.DB {
 	return db
 }
 
-// newRoundtripDatabase creates the throwaway database and registers its teardown.
 func newRoundtripDatabase(t *testing.T, options []pgdriver.Option) (*bun.DB, error) {
 	t.Helper()
 
@@ -343,8 +287,7 @@ func newRoundtripDatabase(t *testing.T, options []pgdriver.Option) (*bun.DB, err
 		return nil, fmt.Errorf("create the roundtrip database: %w", err)
 	}
 
-	// Registered while the maintenance pool is still open, so a failure below cannot strand the
-	// database. Cleanup is LIFO, so the pool opened further down closes before the drop runs.
+	// Register before opening the test pool so cleanup runs after that pool closes.
 	t.Cleanup(func() {
 		// t.Context is already cancelled by the time cleanups run.
 		ctx := context.Background()

--- a/postgres/roundtrip.go
+++ b/postgres/roundtrip.go
@@ -1,0 +1,374 @@
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
+	"github.com/uptrace/bun/migrate"
+)
+
+const (
+	// roundtripInstancePrefix names the throwaway database one roundtrip runs against. Unlike the
+	// databases RunDBTest clones, it starts empty: the run's whole subject is what the migrations
+	// do to a virgin database, so there is nothing to clone from.
+	roundtripInstancePrefix = "goroundtrip_"
+
+	// roundtripSnapshotExt is the extension of a committed snapshot. Plain text, because its
+	// review value is that a reader can see a migration's effect on the schema in a pull request.
+	roundtripSnapshotExt = ".txt"
+
+	// roundtripUpdateEnv, when set to any non-empty value, makes a run rewrite the committed
+	// snapshots instead of comparing against them.
+	//
+	// An environment variable rather than a test flag: this package is linked into every
+	// consumer's test binary, and a flag registered here would collide with a consumer that
+	// defines its own.
+	roundtripUpdateEnv = "GOLIB_UPDATE_SNAPSHOTS"
+
+	// roundtripSchema is the schema migrations land in. Services run one schema per database, so
+	// the roundtrip has no reason to take it as a parameter.
+	roundtripSchema = "public"
+)
+
+// errMigrationDrift reports that the schema is not where a migration should have left it. It stays
+// unexported because RunMigrationRoundtripTest fails the test rather than handing it back; only
+// this package's own tests distinguish it from an infrastructure failure.
+var errMigrationDrift = errors.New("schema drift")
+
+// RoundtripOptions tunes [RunMigrationRoundtripTest]. The zero value runs the roundtrip against a
+// schema that never holds rows and keeps no snapshots on disk.
+type RoundtripOptions struct {
+	// Fixtures holds SQL files named for the migration they follow, as `<timestamp>_<name>.sql`.
+	// A fixture runs after its migration, so its rows are what the next migration's up and its own
+	// migration's down both have to survive.
+	//
+	// Seeding at the step rather than at the end is what puts data in front of the up migrations
+	// too: a column added NOT NULL with no default succeeds on an empty table and fails on a
+	// populated one, and only the second is what production does.
+	//
+	// A migration with no matching file simply seeds nothing.
+	Fixtures fs.FS
+
+	// Snapshots is the directory holding one committed snapshot per migration. When set, each
+	// snapshot taken on the way up is compared against the file for that migration, so an edit to
+	// an already-merged migration surfaces as a diff on a file that should never move again.
+	//
+	// Setting GOLIB_UPDATE_SNAPSHOTS rewrites the files instead of comparing.
+	Snapshots string
+}
+
+// RunMigrationRoundtripTest proves that every down migration exactly reverses its up.
+//
+// It applies the migrations one at a time against a throwaway database, snapshotting the schema
+// after each, then rolls them back one at a time and requires every rollback to land exactly on the
+// state before its migration. Finally it re-applies the whole set, which catches a down migration
+// that leaves the database in a state the up cannot run against a second time.
+//
+// Verifying each step, rather than only the end state, is what localises a failure to the migration
+// that caused it. A rollback that overshoots and one that stops short both end at the wrong place,
+// but the step that first diverged names which migration to fix.
+//
+// config must expose Options() []pgdriver.Option, as postgrespresets.Default does.
+func RunMigrationRoundtripTest(t *testing.T, config Config, migrations fs.FS, opts *RoundtripOptions) {
+	t.Helper()
+
+	require.NoError(t, verifyRoundtrip(t.Context(), roundtripDatabase(t, config), migrations, opts))
+}
+
+// verifyRoundtrip carries the whole roundtrip. It returns errors rather than failing a test so that
+// this package can test what it does when a migration set is broken, which is the behaviour that
+// matters most.
+func verifyRoundtrip(ctx context.Context, db *bun.DB, migrations fs.FS, opts *RoundtripOptions) error {
+	if opts == nil {
+		opts = &RoundtripOptions{}
+	}
+
+	discovery := migrate.NewMigrations()
+
+	err := discovery.Discover(migrations)
+	if err != nil {
+		return fmt.Errorf("discover migrations: %w", err)
+	}
+
+	ordered := discovery.Sorted()
+	if len(ordered) == 0 {
+		return errors.New("no migrations discovered — the roundtrip would assert nothing")
+	}
+
+	err = migrate.NewMigrator(db, roundtripPrefix(ordered, len(ordered))).Init(ctx)
+	if err != nil {
+		return fmt.Errorf("initialise the migration bookkeeping: %w", err)
+	}
+
+	// states[k] is the schema after the first k migrations; states[0] is the virgin database.
+	states := make([]string, len(ordered)+1)
+
+	states[0], err = SchemaSnapshot(ctx, db, roundtripSchema)
+	if err != nil {
+		return err
+	}
+
+	for step := 1; step <= len(ordered); step++ {
+		states[step], err = roundtripUp(ctx, db, ordered, step)
+		if err != nil {
+			return err
+		}
+
+		err = roundtripCheckSnapshot(opts, ordered[step-1], states[step])
+		if err != nil {
+			return err
+		}
+
+		err = roundtripApplyFixture(ctx, db, opts, ordered[step-1])
+		if err != nil {
+			return err
+		}
+	}
+
+	for step := len(ordered); step >= 1; step-- {
+		err = roundtripDown(ctx, db, ordered, step, states[step-1])
+		if err != nil {
+			// Drift cascades: every remaining rollback would report the same difference, so the
+			// run stops at the migration that introduced it rather than repeating itself.
+			return err
+		}
+	}
+
+	return roundtripReplay(ctx, db, ordered, states[len(ordered)])
+}
+
+// roundtripUp applies migration number step and nothing else, and snapshots the result.
+func roundtripUp(ctx context.Context, db *bun.DB, ordered migrate.MigrationSlice, step int) (string, error) {
+	slug := roundtripSlug(ordered[step-1])
+
+	group, err := migrate.NewMigrator(db, roundtripPrefix(ordered, step)).Migrate(ctx)
+	if err != nil {
+		return "", fmt.Errorf("up migration %s: %w", slug, err)
+	}
+
+	if len(group.Migrations) != 1 {
+		return "", fmt.Errorf(
+			"up migration %s formed a group of %d migrations, want exactly 1 so that rolling the "+
+				"group back reverts one migration", slug, len(group.Migrations))
+	}
+
+	return SchemaSnapshot(ctx, db, roundtripSchema)
+}
+
+// roundtripDown rolls back migration number step and requires the schema to land on want.
+func roundtripDown(
+	ctx context.Context, db *bun.DB, ordered migrate.MigrationSlice, step int, want string,
+) error {
+	slug := roundtripSlug(ordered[step-1])
+
+	group, err := migrate.NewMigrator(db, roundtripPrefix(ordered, step)).Rollback(ctx)
+	if err != nil {
+		return fmt.Errorf("down migration %s: %w", slug, err)
+	}
+
+	if len(group.Migrations) != 1 {
+		return fmt.Errorf("the rollback of %s reverted %d migrations, want exactly 1",
+			slug, len(group.Migrations))
+	}
+
+	got, err := SchemaSnapshot(ctx, db, roundtripSchema)
+	if err != nil {
+		return err
+	}
+
+	if delta := SnapshotDelta(want, got); len(delta) > 0 {
+		return fmt.Errorf("%w: down migration %s did not restore the previous schema:\n  %s",
+			errMigrationDrift, slug, strings.Join(delta, "\n  "))
+	}
+
+	return nil
+}
+
+// roundtripReplay re-applies every migration to the rolled-back database and requires the schema to
+// come back identical.
+func roundtripReplay(ctx context.Context, db *bun.DB, ordered migrate.MigrationSlice, want string) error {
+	_, err := migrate.NewMigrator(db, roundtripPrefix(ordered, len(ordered))).Migrate(ctx)
+	if err != nil {
+		return fmt.Errorf("re-apply the migrations after a full rollback: %w", err)
+	}
+
+	got, err := SchemaSnapshot(ctx, db, roundtripSchema)
+	if err != nil {
+		return err
+	}
+
+	if delta := SnapshotDelta(want, got); len(delta) > 0 {
+		return fmt.Errorf(
+			"%w: re-applying every migration after a full rollback produced a different schema:\n  %s",
+			errMigrationDrift, strings.Join(delta, "\n  "))
+	}
+
+	return nil
+}
+
+// roundtripPrefix builds a migration set holding only the first n of ordered.
+//
+// Bun stamps every migration applied by one Migrate call with a single group id, and rolls back a
+// whole group at a time. A set that ends at migration n therefore leaves exactly one migration
+// pending, which is what makes its group one migration wide — and a rollback of that group revert
+// one migration rather than the entire set.
+func roundtripPrefix(ordered migrate.MigrationSlice, n int) *migrate.Migrations {
+	set := migrate.NewMigrations()
+	for _, migration := range ordered[:n] {
+		set.Add(migration)
+	}
+
+	return set
+}
+
+// roundtripSlug rebuilds the stem of a migration's filename, which is how its fixture and its
+// committed snapshot are named. Bun splits the filename into a timestamp and a comment; neither
+// half identifies a migration on its own.
+func roundtripSlug(migration migrate.Migration) string {
+	if migration.Comment == "" {
+		return migration.Name
+	}
+
+	return migration.Name + "_" + migration.Comment
+}
+
+// roundtripApplyFixture runs the fixture belonging to a migration, if there is one.
+func roundtripApplyFixture(
+	ctx context.Context, db *bun.DB, opts *RoundtripOptions, migration migrate.Migration,
+) error {
+	if opts.Fixtures == nil {
+		return nil
+	}
+
+	name := roundtripSlug(migration) + ".sql"
+
+	body, err := fs.ReadFile(opts.Fixtures, name)
+	if err != nil {
+		// A migration that needs no rows of its own is the common case, so an absent fixture is
+		// not a failure. Any other read error is.
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("read fixture %s: %w", name, err)
+	}
+
+	_, err = db.NewRaw(string(body)).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("apply fixture %s: %w", name, err)
+	}
+
+	return nil
+}
+
+// roundtripCheckSnapshot compares a snapshot against its committed file, or rewrites the file when
+// the update variable is set.
+func roundtripCheckSnapshot(opts *RoundtripOptions, migration migrate.Migration, got string) error {
+	if opts.Snapshots == "" {
+		return nil
+	}
+
+	path := filepath.Join(opts.Snapshots, roundtripSlug(migration)+roundtripSnapshotExt)
+
+	if os.Getenv(roundtripUpdateEnv) != "" {
+		err := os.MkdirAll(opts.Snapshots, 0o750)
+		if err != nil {
+			return fmt.Errorf("create the snapshot directory: %w", err)
+		}
+
+		err = os.WriteFile(path, []byte(got), 0o600)
+		if err != nil {
+			return fmt.Errorf("write snapshot %s: %w", path, err)
+		}
+
+		return nil
+	}
+
+	want, err := os.ReadFile(path) //nolint:gosec // the path is built from a migration filename.
+	if err != nil {
+		return fmt.Errorf("read snapshot %s — run with %s=1 to record it: %w",
+			path, roundtripUpdateEnv, err)
+	}
+
+	if delta := SnapshotDelta(string(want), got); len(delta) > 0 {
+		return fmt.Errorf(
+			"%w: migration %s no longer produces its committed schema. A merged migration must not "+
+				"change; if this one legitimately did, re-record with %s=1.\n  %s",
+			errMigrationDrift, roundtripSlug(migration), roundtripUpdateEnv, strings.Join(delta, "\n  "))
+	}
+
+	return nil
+}
+
+// roundtripDatabase creates an empty database for one roundtrip and drops it on cleanup.
+func roundtripDatabase(t *testing.T, config Config) *bun.DB {
+	t.Helper()
+
+	optionsConfig, ok := config.(dbTestOptionsConfig)
+	require.Truef(t, ok,
+		"RunMigrationRoundtripTest requires a Config exposing Options() []pgdriver.Option "+
+			"(e.g. postgrespresets.Default)")
+
+	db, err := newRoundtripDatabase(t, optionsConfig.Options())
+	require.NoError(t, err)
+
+	return db
+}
+
+// newRoundtripDatabase creates the throwaway database and registers its teardown.
+func newRoundtripDatabase(t *testing.T, options []pgdriver.Option) (*bun.DB, error) {
+	t.Helper()
+
+	instance := roundtripInstancePrefix + strings.ToLower(rand.Text())
+
+	maintenance, err := dbTestOpen(t.Context(), options, dbTestMaintenanceDatabase)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = maintenance.NewRaw("CREATE DATABASE " + dbTestQuoteIdent(instance)).Exec(t.Context())
+	if err != nil {
+		_ = maintenance.Close()
+
+		return nil, fmt.Errorf("create the roundtrip database: %w", err)
+	}
+
+	// Registered while the maintenance pool is still open, so a failure below cannot strand the
+	// database. Cleanup is LIFO, so the pool opened further down closes before the drop runs.
+	t.Cleanup(func() {
+		// t.Context is already cancelled by the time cleanups run.
+		ctx := context.Background()
+
+		cleanup, cleanupErr := dbTestOpen(ctx, options, dbTestMaintenanceDatabase)
+		if cleanupErr != nil {
+			return
+		}
+		defer func() { _ = cleanup.Close() }()
+
+		_ = dbTestDropDatabase(ctx, cleanup, instance)
+	})
+
+	err = maintenance.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := dbTestOpen(t.Context(), options, instance)
+	if err != nil {
+		return nil, err
+	}
+
+	t.Cleanup(func() { _ = db.Close() })
+
+	return db, nil
+}

--- a/postgres/roundtrip_internal_test.go
+++ b/postgres/roundtrip_internal_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/uptrace/bun/migrate"
 )
 
-// The roundtrip is tested from inside the package so that the failures can be inspected. Its
-// exported entry point fails a test rather than returning, which is right for callers and useless
-// for proving it fails on the right things.
-
-// roundtripTestDB stands up the throwaway database one verifyRoundtrip call runs against.
 func roundtripTestDB(t *testing.T) *bun.DB {
 	t.Helper()
 
@@ -39,8 +34,6 @@ func TestVerifyRoundtripAcceptsAReversibleSet(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// The defect is a down migration that drops the column it added but leaves its enum type behind —
-// the shape of bug a schema comparison blind to types reports as a clean rollback.
 func TestVerifyRoundtripCatchesAnObjectLeftBehind(t *testing.T) {
 	t.Parallel()
 
@@ -54,8 +47,6 @@ func TestVerifyRoundtripCatchesAnObjectLeftBehind(t *testing.T) {
 		"the failure must name the object left behind")
 }
 
-// Fixtures are seeded between steps so an up migration meets rows, not just an empty table. The two
-// halves here run the same migrations and differ only in whether anything was seeded.
 func TestVerifyRoundtripAppliesFixturesBeforeTheNextMigration(t *testing.T) {
 	t.Parallel()
 
@@ -79,10 +70,6 @@ func TestVerifyRoundtripAppliesFixturesBeforeTheNextMigration(t *testing.T) {
 	})
 }
 
-// Not parallel: recording is switched on by an environment variable, which is process-wide, and
-// t.Setenv panics in a parallel test. Only runs that set Snapshots ever read it, and they all live
-// here.
-//
 //nolint:paralleltest // t.Setenv is incompatible with t.Parallel.
 func TestVerifyRoundtripSnapshots(t *testing.T) {
 	migrations := os.DirFS("testdata/roundtrip/migrations")
@@ -98,8 +85,6 @@ func TestVerifyRoundtripSnapshots(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, recorded, 3, "one snapshot per migration")
 
-		// The second pass compares instead of recording, so it proves the recorded files describe
-		// what the migrations actually produce.
 		t.Setenv(roundtripUpdateEnv, "")
 		require.NoError(t, verifyRoundtrip(t.Context(), roundtripTestDB(t), migrations,
 			&RoundtripOptions{Snapshots: dir}))
@@ -114,8 +99,6 @@ func TestVerifyRoundtripSnapshots(t *testing.T) {
 
 		t.Setenv(roundtripUpdateEnv, "")
 
-		// Stands for a merged migration having been edited: the file no longer describes the
-		// schema the migration builds.
 		edited := filepath.Join(dir, "20260725000001_probe_table.txt")
 		require.NoError(t, os.WriteFile(edited, []byte("relation\troundtrip_probe\tr\n"), 0o600))
 
@@ -144,9 +127,6 @@ func TestVerifyRoundtripRejectsAnEmptyMigrationSet(t *testing.T) {
 	require.ErrorContains(t, err, "no migrations discovered")
 }
 
-// The group width is the mechanic the whole roundtrip rests on: bun rolls back a group at a time,
-// so a group holding more than one migration would revert several at once and the per-step
-// comparison would be meaningless.
 func TestRoundtripPrefixNarrowsTheSetToOnePendingMigration(t *testing.T) {
 	t.Parallel()
 

--- a/postgres/roundtrip_internal_test.go
+++ b/postgres/roundtrip_internal_test.go
@@ -1,0 +1,171 @@
+package postgres
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/driver/pgdriver"
+	"github.com/uptrace/bun/migrate"
+)
+
+// The roundtrip is tested from inside the package so that the failures can be inspected. Its
+// exported entry point fails a test rather than returning, which is right for callers and useless
+// for proving it fails on the right things.
+
+// roundtripTestDB stands up the throwaway database one verifyRoundtrip call runs against.
+func roundtripTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	dsn := os.Getenv("POSTGRES_DSN")
+	require.NotEmpty(t, dsn,
+		"POSTGRES_DSN must point at a throwaway database — the roundtrip migrates a real one")
+
+	db, err := newRoundtripDatabase(t, []pgdriver.Option{pgdriver.WithDSN(dsn)})
+	require.NoError(t, err)
+
+	return db
+}
+
+func TestVerifyRoundtripAcceptsAReversibleSet(t *testing.T) {
+	t.Parallel()
+
+	err := verifyRoundtrip(t.Context(), roundtripTestDB(t),
+		os.DirFS("testdata/roundtrip/migrations"),
+		&RoundtripOptions{Fixtures: os.DirFS("testdata/roundtrip/fixtures")})
+
+	require.NoError(t, err)
+}
+
+// The defect is a down migration that drops the column it added but leaves its enum type behind —
+// the shape of bug a schema comparison blind to types reports as a clean rollback.
+func TestVerifyRoundtripCatchesAnObjectLeftBehind(t *testing.T) {
+	t.Parallel()
+
+	err := verifyRoundtrip(t.Context(), roundtripTestDB(t),
+		os.DirFS("testdata/roundtrip-broken/migrations"), nil)
+
+	require.ErrorIs(t, err, errMigrationDrift)
+	require.Contains(t, err.Error(), "20260725000002_probe_status",
+		"the failure must name the migration whose down is at fault")
+	require.Contains(t, err.Error(), "roundtrip_status",
+		"the failure must name the object left behind")
+}
+
+// Fixtures are seeded between steps so an up migration meets rows, not just an empty table. The two
+// halves here run the same migrations and differ only in whether anything was seeded.
+func TestVerifyRoundtripAppliesFixturesBeforeTheNextMigration(t *testing.T) {
+	t.Parallel()
+
+	migrations := os.DirFS("testdata/roundtrip-strict/migrations")
+
+	t.Run("passes against an empty table", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, verifyRoundtrip(t.Context(), roundtripTestDB(t), migrations, nil))
+	})
+
+	t.Run("fails once the previous migration's fixture has seeded a row", func(t *testing.T) {
+		t.Parallel()
+
+		err := verifyRoundtrip(t.Context(), roundtripTestDB(t), migrations,
+			&RoundtripOptions{Fixtures: os.DirFS("testdata/roundtrip/fixtures")})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "20260725000002_probe_required")
+		require.Contains(t, err.Error(), "contains null values")
+	})
+}
+
+// Not parallel: recording is switched on by an environment variable, which is process-wide, and
+// t.Setenv panics in a parallel test. Only runs that set Snapshots ever read it, and they all live
+// here.
+//
+//nolint:paralleltest // t.Setenv is incompatible with t.Parallel.
+func TestVerifyRoundtripSnapshots(t *testing.T) {
+	migrations := os.DirFS("testdata/roundtrip/migrations")
+
+	t.Run("records then re-reads them", func(t *testing.T) {
+		dir := t.TempDir()
+
+		t.Setenv(roundtripUpdateEnv, "1")
+		require.NoError(t, verifyRoundtrip(t.Context(), roundtripTestDB(t), migrations,
+			&RoundtripOptions{Snapshots: dir}))
+
+		recorded, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Len(t, recorded, 3, "one snapshot per migration")
+
+		// The second pass compares instead of recording, so it proves the recorded files describe
+		// what the migrations actually produce.
+		t.Setenv(roundtripUpdateEnv, "")
+		require.NoError(t, verifyRoundtrip(t.Context(), roundtripTestDB(t), migrations,
+			&RoundtripOptions{Snapshots: dir}))
+	})
+
+	t.Run("rejects a snapshot that no longer matches", func(t *testing.T) {
+		dir := t.TempDir()
+
+		t.Setenv(roundtripUpdateEnv, "1")
+		require.NoError(t, verifyRoundtrip(t.Context(), roundtripTestDB(t), migrations,
+			&RoundtripOptions{Snapshots: dir}))
+
+		t.Setenv(roundtripUpdateEnv, "")
+
+		// Stands for a merged migration having been edited: the file no longer describes the
+		// schema the migration builds.
+		edited := filepath.Join(dir, "20260725000001_probe_table.txt")
+		require.NoError(t, os.WriteFile(edited, []byte("relation\troundtrip_probe\tr\n"), 0o600))
+
+		err := verifyRoundtrip(t.Context(), roundtripTestDB(t), migrations,
+			&RoundtripOptions{Snapshots: dir})
+
+		require.ErrorIs(t, err, errMigrationDrift)
+		require.Contains(t, err.Error(), "20260725000001_probe_table")
+	})
+
+	t.Run("reports a snapshot that was never recorded", func(t *testing.T) {
+		err := verifyRoundtrip(t.Context(), roundtripTestDB(t), migrations,
+			&RoundtripOptions{Snapshots: t.TempDir()})
+
+		require.ErrorIs(t, err, os.ErrNotExist)
+		require.Contains(t, err.Error(), roundtripUpdateEnv,
+			"the failure must say how to record the missing snapshot")
+	})
+}
+
+func TestVerifyRoundtripRejectsAnEmptyMigrationSet(t *testing.T) {
+	t.Parallel()
+
+	err := verifyRoundtrip(t.Context(), roundtripTestDB(t), os.DirFS(t.TempDir()), nil)
+
+	require.ErrorContains(t, err, "no migrations discovered")
+}
+
+// The group width is the mechanic the whole roundtrip rests on: bun rolls back a group at a time,
+// so a group holding more than one migration would revert several at once and the per-step
+// comparison would be meaningless.
+func TestRoundtripPrefixNarrowsTheSetToOnePendingMigration(t *testing.T) {
+	t.Parallel()
+
+	ordered := migrate.MigrationSlice{
+		{Name: "20260725000001", Comment: "first"},
+		{Name: "20260725000002", Comment: "second"},
+		{Name: "20260725000003", Comment: "third"},
+	}
+
+	require.Len(t, roundtripPrefix(ordered, 1).Sorted(), 1)
+	require.Len(t, roundtripPrefix(ordered, 2).Sorted(), 2)
+	require.Equal(t, "20260725000002", roundtripPrefix(ordered, 2).Sorted()[1].Name)
+}
+
+func TestRoundtripSlug(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "20260725000001_probe_table",
+		roundtripSlug(migrate.Migration{Name: "20260725000001", Comment: "probe_table"}))
+	require.Equal(t, "20260725000001",
+		roundtripSlug(migrate.Migration{Name: "20260725000001"}))
+}

--- a/postgres/roundtrip_test.go
+++ b/postgres/roundtrip_test.go
@@ -7,9 +7,6 @@ import (
 	"github.com/a-novel-kit/golib/postgres"
 )
 
-// The exported entry point is what services call, so it is exercised the way they will: a preset
-// config, an embedded migration set, and fixtures beside it. Everything it can report is tested
-// from inside the package, since failing the test is all a caller ever sees of it.
 func TestRunMigrationRoundtripTest(t *testing.T) {
 	t.Parallel()
 

--- a/postgres/roundtrip_test.go
+++ b/postgres/roundtrip_test.go
@@ -1,0 +1,19 @@
+package postgres_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/a-novel-kit/golib/postgres"
+)
+
+// The exported entry point is what services call, so it is exercised the way they will: a preset
+// config, an embedded migration set, and fixtures beside it. Everything it can report is tested
+// from inside the package, since failing the test is all a caller ever sees of it.
+func TestRunMigrationRoundtripTest(t *testing.T) {
+	t.Parallel()
+
+	postgres.RunMigrationRoundtripTest(t, testConfig(t),
+		os.DirFS("testdata/roundtrip/migrations"),
+		&postgres.RoundtripOptions{Fixtures: os.DirFS("testdata/roundtrip/fixtures")})
+}

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000001_probe_table.down.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000001_probe_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS roundtrip_probe;

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000001_probe_table.up.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000001_probe_table.up.sql
@@ -1,6 +1,3 @@
--- The table the roundtrip fixtures seed and the later migrations extend. It exists only so the
--- harness has a schema to take apart, so it carries one of each thing a down migration has to
--- reverse: a default, a not-null, and a check.
 CREATE TABLE roundtrip_probe (
   id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
   name text NOT NULL CHECK (name <> '')

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000001_probe_table.up.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000001_probe_table.up.sql
@@ -1,0 +1,7 @@
+-- The table the roundtrip fixtures seed and the later migrations extend. It exists only so the
+-- harness has a schema to take apart, so it carries one of each thing a down migration has to
+-- reverse: a default, a not-null, and a check.
+CREATE TABLE roundtrip_probe (
+  id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL CHECK (name <> '')
+);

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000002_probe_status.down.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000002_probe_status.down.sql
@@ -1,0 +1,4 @@
+-- Deliberately defective: the column goes, the type it introduced stays behind. This is the shape
+-- of rollback bug a type-blind schema comparison passes, and the roundtrip must catch it.
+ALTER TABLE roundtrip_probe
+DROP COLUMN IF EXISTS status;

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000002_probe_status.down.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000002_probe_status.down.sql
@@ -1,4 +1,3 @@
--- Deliberately defective: the column goes, the type it introduced stays behind. This is the shape
--- of rollback bug a type-blind schema comparison passes, and the roundtrip must catch it.
+-- Intentionally leaves roundtrip_status behind.
 ALTER TABLE roundtrip_probe
 DROP COLUMN IF EXISTS status;

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000002_probe_status.up.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000002_probe_status.up.sql
@@ -1,9 +1,4 @@
--- An enum plus a column that uses it. The pair is what makes the paired down migration a real
--- test: dropping the column alone leaves the type behind, and a schema comparison that cannot see
--- types would call that a clean rollback.
 CREATE TYPE roundtrip_status AS ENUM('draft', 'live');
 
--- NOT NULL with a default, so the fixture row seeded by the previous migration is what this has to
--- survive. Without the default it would fail here, which is the point of seeding before the step.
 ALTER TABLE roundtrip_probe
 ADD COLUMN status roundtrip_status NOT NULL DEFAULT 'draft';

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000002_probe_status.up.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000002_probe_status.up.sql
@@ -1,0 +1,9 @@
+-- An enum plus a column that uses it. The pair is what makes the paired down migration a real
+-- test: dropping the column alone leaves the type behind, and a schema comparison that cannot see
+-- types would call that a clean rollback.
+CREATE TYPE roundtrip_status AS ENUM('draft', 'live');
+
+-- NOT NULL with a default, so the fixture row seeded by the previous migration is what this has to
+-- survive. Without the default it would fail here, which is the point of seeding before the step.
+ALTER TABLE roundtrip_probe
+ADD COLUMN status roundtrip_status NOT NULL DEFAULT 'draft';

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000003_probe_index.down.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000003_probe_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS roundtrip_probe_live_name_idx;

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000003_probe_index.up.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000003_probe_index.up.sql
@@ -1,4 +1,3 @@
--- A partial unique index, so the roundtrip covers a predicate a rollback could restore too widely.
 CREATE UNIQUE INDEX roundtrip_probe_live_name_idx ON roundtrip_probe (name)
 WHERE
   status = 'live';

--- a/postgres/testdata/roundtrip-broken/migrations/20260725000003_probe_index.up.sql
+++ b/postgres/testdata/roundtrip-broken/migrations/20260725000003_probe_index.up.sql
@@ -1,0 +1,4 @@
+-- A partial unique index, so the roundtrip covers a predicate a rollback could restore too widely.
+CREATE UNIQUE INDEX roundtrip_probe_live_name_idx ON roundtrip_probe (name)
+WHERE
+  status = 'live';

--- a/postgres/testdata/roundtrip-strict/migrations/20260725000001_probe_table.down.sql
+++ b/postgres/testdata/roundtrip-strict/migrations/20260725000001_probe_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS roundtrip_probe;

--- a/postgres/testdata/roundtrip-strict/migrations/20260725000001_probe_table.up.sql
+++ b/postgres/testdata/roundtrip-strict/migrations/20260725000001_probe_table.up.sql
@@ -1,6 +1,3 @@
--- The table the roundtrip fixtures seed and the later migrations extend. It exists only so the
--- harness has a schema to take apart, so it carries one of each thing a down migration has to
--- reverse: a default, a not-null, and a check.
 CREATE TABLE roundtrip_probe (
   id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
   name text NOT NULL CHECK (name <> '')

--- a/postgres/testdata/roundtrip-strict/migrations/20260725000001_probe_table.up.sql
+++ b/postgres/testdata/roundtrip-strict/migrations/20260725000001_probe_table.up.sql
@@ -1,0 +1,7 @@
+-- The table the roundtrip fixtures seed and the later migrations extend. It exists only so the
+-- harness has a schema to take apart, so it carries one of each thing a down migration has to
+-- reverse: a default, a not-null, and a check.
+CREATE TABLE roundtrip_probe (
+  id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL CHECK (name <> '')
+);

--- a/postgres/testdata/roundtrip-strict/migrations/20260725000002_probe_required.down.sql
+++ b/postgres/testdata/roundtrip-strict/migrations/20260725000002_probe_required.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE roundtrip_probe
+DROP COLUMN IF EXISTS required;

--- a/postgres/testdata/roundtrip-strict/migrations/20260725000002_probe_required.up.sql
+++ b/postgres/testdata/roundtrip-strict/migrations/20260725000002_probe_required.up.sql
@@ -1,0 +1,5 @@
+-- Deliberately missing a default. On an empty table this succeeds; on the row the previous
+-- migration's fixture seeded it cannot. That difference is the whole reason fixtures are applied
+-- between steps rather than after the last one.
+ALTER TABLE roundtrip_probe
+ADD COLUMN required text NOT NULL;

--- a/postgres/testdata/roundtrip-strict/migrations/20260725000002_probe_required.up.sql
+++ b/postgres/testdata/roundtrip-strict/migrations/20260725000002_probe_required.up.sql
@@ -1,5 +1,3 @@
--- Deliberately missing a default. On an empty table this succeeds; on the row the previous
--- migration's fixture seeded it cannot. That difference is the whole reason fixtures are applied
--- between steps rather than after the last one.
+-- Intentionally fails only when the previous fixture inserted a row.
 ALTER TABLE roundtrip_probe
 ADD COLUMN required text NOT NULL;

--- a/postgres/testdata/roundtrip/fixtures/20260725000001_probe_table.sql
+++ b/postgres/testdata/roundtrip/fixtures/20260725000001_probe_table.sql
@@ -1,5 +1,3 @@
--- Seeded before the next migration adds a NOT NULL column, so that migration has to carry a
--- default rather than merely succeeding against an empty table.
 INSERT INTO
   roundtrip_probe (name)
 VALUES

--- a/postgres/testdata/roundtrip/fixtures/20260725000001_probe_table.sql
+++ b/postgres/testdata/roundtrip/fixtures/20260725000001_probe_table.sql
@@ -1,0 +1,6 @@
+-- Seeded before the next migration adds a NOT NULL column, so that migration has to carry a
+-- default rather than merely succeeding against an empty table.
+INSERT INTO
+  roundtrip_probe (name)
+VALUES
+  ('seeded before status');

--- a/postgres/testdata/roundtrip/fixtures/20260725000002_probe_status.sql
+++ b/postgres/testdata/roundtrip/fixtures/20260725000002_probe_status.sql
@@ -1,0 +1,6 @@
+-- A live row, so the partial unique index the next migration creates has to build over data that
+-- matches its predicate.
+INSERT INTO
+  roundtrip_probe (name, status)
+VALUES
+  ('seeded live', 'live');

--- a/postgres/testdata/roundtrip/fixtures/20260725000002_probe_status.sql
+++ b/postgres/testdata/roundtrip/fixtures/20260725000002_probe_status.sql
@@ -1,5 +1,3 @@
--- A live row, so the partial unique index the next migration creates has to build over data that
--- matches its predicate.
 INSERT INTO
   roundtrip_probe (name, status)
 VALUES

--- a/postgres/testdata/roundtrip/migrations/20260725000001_probe_table.down.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000001_probe_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS roundtrip_probe;

--- a/postgres/testdata/roundtrip/migrations/20260725000001_probe_table.up.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000001_probe_table.up.sql
@@ -1,6 +1,3 @@
--- The table the roundtrip fixtures seed and the later migrations extend. It exists only so the
--- harness has a schema to take apart, so it carries one of each thing a down migration has to
--- reverse: a default, a not-null, and a check.
 CREATE TABLE roundtrip_probe (
   id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
   name text NOT NULL CHECK (name <> '')

--- a/postgres/testdata/roundtrip/migrations/20260725000001_probe_table.up.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000001_probe_table.up.sql
@@ -1,0 +1,7 @@
+-- The table the roundtrip fixtures seed and the later migrations extend. It exists only so the
+-- harness has a schema to take apart, so it carries one of each thing a down migration has to
+-- reverse: a default, a not-null, and a check.
+CREATE TABLE roundtrip_probe (
+  id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL CHECK (name <> '')
+);

--- a/postgres/testdata/roundtrip/migrations/20260725000002_probe_status.down.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000002_probe_status.down.sql
@@ -1,4 +1,3 @@
--- The column goes before the type it depends on.
 ALTER TABLE roundtrip_probe
 DROP COLUMN IF EXISTS status;
 

--- a/postgres/testdata/roundtrip/migrations/20260725000002_probe_status.down.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000002_probe_status.down.sql
@@ -1,0 +1,5 @@
+-- The column goes before the type it depends on.
+ALTER TABLE roundtrip_probe
+DROP COLUMN IF EXISTS status;
+
+DROP TYPE IF EXISTS roundtrip_status;

--- a/postgres/testdata/roundtrip/migrations/20260725000002_probe_status.up.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000002_probe_status.up.sql
@@ -1,9 +1,4 @@
--- An enum plus a column that uses it. The pair is what makes the paired down migration a real
--- test: dropping the column alone leaves the type behind, and a schema comparison that cannot see
--- types would call that a clean rollback.
 CREATE TYPE roundtrip_status AS ENUM('draft', 'live');
 
--- NOT NULL with a default, so the fixture row seeded by the previous migration is what this has to
--- survive. Without the default it would fail here, which is the point of seeding before the step.
 ALTER TABLE roundtrip_probe
 ADD COLUMN status roundtrip_status NOT NULL DEFAULT 'draft';

--- a/postgres/testdata/roundtrip/migrations/20260725000002_probe_status.up.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000002_probe_status.up.sql
@@ -1,0 +1,9 @@
+-- An enum plus a column that uses it. The pair is what makes the paired down migration a real
+-- test: dropping the column alone leaves the type behind, and a schema comparison that cannot see
+-- types would call that a clean rollback.
+CREATE TYPE roundtrip_status AS ENUM('draft', 'live');
+
+-- NOT NULL with a default, so the fixture row seeded by the previous migration is what this has to
+-- survive. Without the default it would fail here, which is the point of seeding before the step.
+ALTER TABLE roundtrip_probe
+ADD COLUMN status roundtrip_status NOT NULL DEFAULT 'draft';

--- a/postgres/testdata/roundtrip/migrations/20260725000003_probe_index.down.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000003_probe_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS roundtrip_probe_live_name_idx;

--- a/postgres/testdata/roundtrip/migrations/20260725000003_probe_index.up.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000003_probe_index.up.sql
@@ -1,4 +1,3 @@
--- A partial unique index, so the roundtrip covers a predicate a rollback could restore too widely.
 CREATE UNIQUE INDEX roundtrip_probe_live_name_idx ON roundtrip_probe (name)
 WHERE
   status = 'live';

--- a/postgres/testdata/roundtrip/migrations/20260725000003_probe_index.up.sql
+++ b/postgres/testdata/roundtrip/migrations/20260725000003_probe_index.up.sql
@@ -1,0 +1,4 @@
+-- A partial unique index, so the roundtrip covers a predicate a rollback could restore too widely.
+CREATE UNIQUE INDEX roundtrip_probe_live_name_idx ON roundtrip_probe (name)
+WHERE
+  status = 'live';


### PR DESCRIPTION
## Summary

- Adds `SchemaSnapshot`, a canonical, order-insensitive census of a schema, rendered by PostgreSQL's own `pg_get_*def` family so the text describes the schema that exists rather than the DDL that built it.
- Adds `RunMigrationRoundtripTest`: applies migrations one at a time, snapshotting each state, rolls each back one at a time requiring an exact landing, then re-applies the whole set.
- Per-migration fixtures seed rows *between* steps, so up migrations meet data too — not only down ones.

Closes #417. Part of a-novel/.github#237.

## Why a census rather than a schema-diff library

`ariga/atlas`'s Go SDK was prototyped first and rejected. Its differ is genuinely semantic, but its OSS inspector is blind to **views, materialized views, triggers, functions, sequences, extensions and table storage parameters**, even with every `InspectMode` flag set. `service-jobs` sets `autovacuum_*` today and `service-json-keys` owns a view, so a rollback leaving either behind would have passed silently.

A `pg_dump` text diff was rejected too: it is the approach whose false positives [GitLab documents](https://docs.gitlab.com/development/database/dbcheck-migrations-job) — a column re-added by a rollback lands at the end of the table, and a minor PostgreSQL upgrade reorders objects in the dump.

The third phase (re-apply everything after a full rollback) is [Liquibase's `update-testing-rollback`](https://docs.liquibase.com/commands/update/update-testing-rollback.html): a down migration can land on the right schema and still leave the database in a state the up cannot run against a second time.

## The mechanic worth knowing

Bun rolls back a whole migration **group**, and one `Migrate()` call stamps every pending migration with the same group id — so applying N migrations and rolling back reverts all N at once. The harness feeds the migrator a set truncated to the first *k* files, which leaves exactly one migration pending and keeps each group one migration wide. `roundtripUp`/`roundtripDown` assert the group width so a bun upgrade fails loudly instead of silently degrading to all-at-once.

## Coverage

Two invariants the design rests on are tested directly, because both fail silently otherwise:

- **OID-free** — two databases built in *deliberately opposite* statement order must render identically. OIDs are assigned in creation order, so a leak would churn every committed snapshot. (An early draft leaked one as a fallback identity for comments.)
- **Order-insensitive** — a column dropped and re-added must read as identical.

The drift matrix covers 21 differences the census must report (storage parameters, `NOT NULL`, defaults, index predicates and sort order, comments, enum label order and membership, FK actions, function bodies and settings, trigger definitions and enablement, views, matviews, sequences, extensions, RLS policy semantics, grants, extended statistics) and 4 it must not.

An object class the census cannot render returns `ErrUnsupportedSchemaObject` rather than being skipped — a snapshot that quietly omitted an object would compare equal to one taken before it existed, which is exactly the blindness this exists to rule out.

## Notes for the reviewer

- `verifyRoundtrip` returns errors while `RunMigrationRoundtripTest` fails the test. The split exists so the failure paths — the behaviour that matters most here — are testable at all.
- The `postgres` package's test time goes from ~4s to ~22s. It is PostgreSQL serialising `CREATE DATABASE`; each probe needs its own database because the census covers database-scoped extensions.
- Committed snapshots are recorded with `GOLIB_UPDATE_SNAPSHOTS=1`. An environment variable rather than a test flag, since this package links into every consumer's test binary and a flag would collide.

## Breaking changes

None. New surface only: `SchemaSnapshot`, `SnapshotDelta`, `RunMigrationRoundtripTest`, `RoundtripOptions`, `ErrUnsupportedSchemaObject`.

## Test plan

- [x] `go test ./...` passes with `POSTGRES_DSN` set (PostgreSQL 18)
- [x] `pnpm lint:go` — 0 issues
- [x] `pnpm lint:prettier` — clean
- [x] A sabotaged down migration (drops its column, leaves its enum type) is caught and names both the migration and the object
- [x] A migration that only fails against seeded data is caught by its fixture, and passes without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)