### PR TITLE
ci(ci): use shared Go generation action

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.28.0
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -20,7 +20,7 @@ jobs:
     # the callee mints a scoped App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       dependency_bot_login: ${{ vars.DEPENDENCY_BOT_LOGIN }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -11,6 +11,6 @@ jobs:
       pull-requests: write
     if: ${{ github.event.pull_request.user.login != vars.DEPENDENCY_BOT_LOGIN }}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -33,7 +33,7 @@ jobs:
     # a stray forward is sweep-only, so a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -52,7 +52,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.28.0
     with:
       epic_number: ${{ inputs.epic_number }}
       confirm: ${{ inputs.confirm }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: write
       actions: read
-    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.28.0
     with:
       line: ${{ inputs.line }}
       fix_ref: ${{ inputs.fix_ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,25 +13,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: "go.mod"
-      - name: go generate
-        shell: bash
-        run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
-        with:
-          fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
+      - uses: a-novel-kit/workflows/go-actions/generate-go@v1.28.0
 
   lint-go:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.27.1
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.28.0
 
   lint-proto:
     runs-on: ubuntu-latest
@@ -48,7 +37,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.28.0
         with:
           # `lint` is now the local umbrella (go + proto + prettier); the
           # node CI runner has no Go/buf toolchain, so it runs the node-only
@@ -67,7 +56,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.28.0
         with:
           ruleset: none
           # renovate: datasource=docker depName=semgrep/semgrep
@@ -83,7 +72,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.28.0
         with:
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
           version: "8.30.1"
@@ -98,7 +87,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.27.1
+      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.28.0
         with:
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
@@ -130,6 +119,6 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.28.0
         with:
           modfile: gotestsum.mod

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -34,7 +34,7 @@ jobs:
     # the callee mints its own App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/audit@v1.27.1
+      - uses: a-novel-kit/workflows/node-actions/audit@v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -39,7 +39,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.27.1
+    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.28.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.27.1
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.28.0
         with:
           # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
           cli_version: "1.7.5"
@@ -58,7 +58,7 @@ jobs:
       # Everything on the default branch just shipped — clear this repo's
       # awaiting-release items off the board. Skipped on a dry run.
       - if: ${{ !inputs.dry_run }}
-        uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.27.1
+        uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.28.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.27.1
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.28.0
         with:
           allowed_commands: |
             [


### PR DESCRIPTION
## Summary

- Replaces the repository-local generated-Go CI sequence with `generate-go@v1.28.0`.
- Preserves caller-owned job services and dependencies.
- Aligns all shared workflow-action references on the released `v1.28.0` tag.

## Layers changed

- **CI**: generated-code verification and shared-action pins.

## Breaking changes

None.

## Test plan

- [x] Repository Prettier check passes.
- [x] Focused workflow diff review and stale-pin guard pass.
- [ ] CI green

Closes #422

Part of a-novel/.github#239.