### PR TITLE
fix(ci): keep Renovate npm formatting Node-only

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           allowed_commands: |
             [
-              "^pnpm format$", 
+              "^pnpm format:prettier$",
               "^go mod download$", 
               "^go mod download .*", 
               "^rm -f .*",

--- a/renovate.json
+++ b/renovate.json
@@ -55,7 +55,7 @@
       "matchManagers": ["npm"],
       "postUpdateOptions": ["pnpmDedupe"],
       "postUpgradeTasks": {
-        "commands": ["pnpm format"],
+        "commands": ["pnpm format:prettier"],
         "executionMode": "branch"
       }
     }


### PR DESCRIPTION
## Summary

- Keeps Renovate npm artifact formatting on the Prettier-only lane.
- Prevents `go: not found` artifact failures after the generic formatter became an all-language umbrella.

## Breaking changes

None.

## Test plan

- [x] `pnpm format:prettier` passes
- [x] `pnpm lint:prettier` passes
- [ ] CI green