### PR TITLE
fix(smtp): support distinct authentication usernames

### DIFF
--- a/smtp/sender.prod.go
+++ b/smtp/sender.prod.go
@@ -23,14 +23,15 @@ const DefaultTimeout = 30 * time.Second
 // stops there: every message goes out authenticated.
 var ErrNoAuthSupport = errors.New("SMTP server does not support AUTH")
 
-// ProdSender delivers mail through a real SMTP server using net/smtp. Its
-// fields are populated from configuration; the password is never serialized
-// back out.
+// ProdSender delivers mail through a real SMTP server using net/smtp. Email controls the envelope
+// sender and visible From header. Username controls SMTP authentication and falls back to Email
+// when empty. The password is never serialized back out.
 type ProdSender struct {
-	Addr   string `json:"addr"   yaml:"addr"`
-	Name   string `json:"name"   yaml:"name"`
-	Email  string `json:"email"  yaml:"email"`
-	Domain string `json:"domain" yaml:"domain"`
+	Addr     string `json:"addr"     yaml:"addr"`
+	Name     string `json:"name"     yaml:"name"`
+	Email    string `json:"email"    yaml:"email"`
+	Username string `json:"username" yaml:"username"`
+	Domain   string `json:"domain"   yaml:"domain"`
 
 	Password string `json:"-" yaml:"-"`
 
@@ -140,7 +141,14 @@ func (sender *ProdSender) timeout() time.Duration {
 }
 
 func (sender *ProdSender) auth() smtp.Auth {
-	auth := smtp.PlainAuth(sender.Name, sender.Email, sender.Password, sender.Domain)
+	username := sender.Username
+	if username == "" {
+		// Existing callers use the sender address as their SMTP login. Keep that contract while
+		// allowing relays such as Brevo to provide a separate account username.
+		username = sender.Email
+	}
+
+	auth := smtp.PlainAuth("", username, sender.Password, sender.Domain)
 	if sender.ForceUnencryptedTls {
 		return unencryptedAuth{auth}
 	}

--- a/smtp/sender.prod_test.go
+++ b/smtp/sender.prod_test.go
@@ -2,6 +2,7 @@ package smtp_test
 
 import (
 	"bufio"
+	"encoding/base64"
 	"errors"
 	"net"
 	"strings"
@@ -61,6 +62,8 @@ func newFakeServer(t *testing.T, stall bool) *fakeServer {
 }
 
 func (s *fakeServer) addr() string { return s.listener.Addr().String() }
+
+func (s *fakeServer) wait() { <-s.done }
 
 func (s *fakeServer) serve() {
 	defer close(s.done)
@@ -139,41 +142,88 @@ func testTemplate(t *testing.T) *template.Template {
 	return tmpl
 }
 
+func plainAuthCredentials(t *testing.T, transcript []string) (string, string, string) {
+	t.Helper()
+
+	for _, line := range transcript {
+		payload, ok := strings.CutPrefix(line, "AUTH PLAIN ")
+		if !ok {
+			continue
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(payload)
+		require.NoError(t, err)
+
+		credentials := strings.Split(string(decoded), "\x00")
+		require.Len(t, credentials, 3)
+
+		return credentials[0], credentials[1], credentials[2]
+	}
+
+	require.FailNow(t, "AUTH PLAIN command not found")
+
+	return "", "", ""
+}
+
 func TestProdSenderSendMail(t *testing.T) {
 	t.Parallel()
 
-	server := newFakeServer(t, false)
-
-	host, _, err := net.SplitHostPort(server.addr())
-	require.NoError(t, err)
-
-	sender := &smtp.ProdSender{
-		Addr:  server.addr(),
-		Name:  "Agora",
-		Email: "noreply@example.com",
-		// The fake accepts any credential; what matters is that AUTH is attempted at all.
-		Password: "hunter2",
-		// PlainAuth checks this against the server it is talking to, so Domain is the SMTP host.
-		Domain: host,
+	testCases := map[string]struct {
+		username         string
+		expectedUsername string
+	}{
+		"distinct authentication username": {
+			username:         "relay-user@example.net",
+			expectedUsername: "relay-user@example.net",
+		},
+		"sender email fallback": {
+			expectedUsername: "noreply@example.com",
+		},
 	}
 
-	err = sender.SendMail(
-		smtp.MailUsers{{Name: "Recipient", Email: "to@example.com"}},
-		testTemplate(t), "mail", "world",
-	)
-	require.NoError(t, err)
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	joined := strings.Join(server.transcript, "\n")
-	require.Contains(t, joined, "AUTH PLAIN", "credentials must be offered")
-	require.Contains(t, joined, "MAIL FROM:<noreply@example.com>")
-	require.Contains(t, joined, "RCPT TO:<to@example.com>")
-	require.Contains(t, joined, "DATA")
-	require.Contains(t, joined, "QUIT")
+			server := newFakeServer(t, false)
 
-	// AUTH before MAIL. The transaction starts only once the client is authenticated.
-	authAt := strings.Index(joined, "AUTH")
-	mailAt := strings.Index(joined, "MAIL FROM")
-	require.Less(t, authAt, mailAt, "AUTH must precede MAIL FROM")
+			host, _, err := net.SplitHostPort(server.addr())
+			require.NoError(t, err)
+
+			sender := &smtp.ProdSender{
+				Addr:     server.addr(),
+				Name:     "Agora",
+				Email:    "noreply@example.com",
+				Username: testCase.username,
+				Password: "hunter2",
+				// PlainAuth checks this against the server it is talking to, so Domain is the SMTP host.
+				Domain: host,
+			}
+
+			err = sender.SendMail(
+				smtp.MailUsers{{Name: "Recipient", Email: "to@example.com"}},
+				testTemplate(t), "mail", "world",
+			)
+			require.NoError(t, err)
+			server.wait()
+
+			joined := strings.Join(server.transcript, "\n")
+			require.Contains(t, joined, "MAIL FROM:<noreply@example.com>")
+			require.Contains(t, joined, "RCPT TO:<to@example.com>")
+			require.Contains(t, joined, "DATA")
+			require.Contains(t, joined, "QUIT")
+
+			identity, username, password := plainAuthCredentials(t, server.transcript)
+			require.Empty(t, identity)
+			require.Equal(t, testCase.expectedUsername, username)
+			require.Equal(t, "hunter2", password)
+
+			// AUTH before MAIL. The transaction starts only once the client is authenticated.
+			authAt := strings.Index(joined, "AUTH")
+			mailAt := strings.Index(joined, "MAIL FROM")
+			require.Less(t, authAt, mailAt, "AUTH must precede MAIL FROM")
+		})
+	}
 }
 
 func TestProdSenderRefusesServerWithoutAuth(t *testing.T) {


### PR DESCRIPTION
## Summary

- Allows SMTP relays to authenticate with a provider-assigned username while keeping the visible sender address independent.
- Preserves existing callers by falling back to the sender email when no username is configured.
- Uses the standard empty PLAIN authorization identity and verifies the encoded credentials at the protocol boundary.

## Breaking changes

None.

## Test plan

- [x] `pnpm lint:go`
- [x] `a-novel test --type=go -y` against disposable PostgreSQL 18.6
- [x] `a-novel build --type=go -y`
- [ ] CI green

Closes a-novel/.github#280
